### PR TITLE
Add instructions to install test_requirements.txt before Make.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ To install all python requirements, run:
 
 ```bash
 pip install -r requirements.txt
+pip install -r test_requirements.txt
 ```
 
 After that, run:


### PR DESCRIPTION
`Make` fails unless you also install the test_requirements.txt requirements.