### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ pynacl==0.3.0
 txrestapi==0.2
 autobahn==0.10.9
 python-obelisk
-requests==2.4.3
+requests==2.6.0
 pyopenssl==0.15.1
 miniupnpc==1.9


### PR DESCRIPTION
Fixes this error when running on Ubuntu 15.10

AttributeError: 'module' object has no attribute 'PROTOCOL_SSLv3'