### PR TITLE
inv/values refactor

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -3,7 +3,7 @@ from os import getcwd
 from os.path import expanduser, join, isfile
 import ConfigParser
 
-PROTOCOL_VERSION = 6
+PROTOCOL_VERSION = 7
 
 dataFolderPath = expanduser('~')
 currentPath = getcwd()

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,4 +3,5 @@ coverage==3.7.1
 mock==1.0.1
 nose==1.3.4
 pylint==1.4.4
+astroid==1.3.8
 python-coveralls==2.5.0


### PR DESCRIPTION
Beginning of a refactor to transfer values between nodes in bulk messages using the inventory/getdata format instead of individual store messages. Should improve efficiency and better enable ban score calculations in the future. 