### PR TITLE
Moved constants out of openbazaard.py

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -7,8 +7,7 @@ folder)
 __author__ = 'foxcarlos-TeamCreed', 'Tobin Harding'
 
 import os
-from platform import platform
-from os.path import expanduser, join, isfile
+from os.path import join, isfile
 from ConfigParser import ConfigParser
 from urlparse import urlparse
 
@@ -135,6 +134,65 @@ def _tuple_from_seed_string(string):
     Accepts well formed seed string, returns tuple (url:port, key)
     '''
     return tuple(string.split(','))
+
+
+def _parse_config_file(config_parser):
+    if is_windows():
+        _parse_windows_config_file(config_parser)
+    elif is_osx():
+        _parse_osx_config_files(config_parser)
+    elif is_linux():
+        _parse_linux_config_files(config_parser)
+
+
+def _parse_windows_config_file(config_parser):
+    if isfile(WINDOWS_CONFIG_FILE):
+        config_parser.read(WINDOWS_CONFIG_FILE)
+    else:
+        print 'Warning: configuration file (%s) not found, using default values' % WINDOWS_CONFIG_FILE
+
+
+def _parse_osx_config_files(config_parser):
+    system_wide_config_file = '/etc/openbazaar.conf'
+
+    # user config file should be ~/Library/Preferences/OpenBazaar.app
+    # but they must be in XML
+
+    options_config_file = options_tmp_path()
+    in_order_config_files = [system_wide_config_file, options_config_file]
+    for config_file in in_order_config_files:
+        config_parser.read(config_file)
+
+
+def _parse_linux_config_files(config_parser):
+    basename = 'openbazaar.conf'
+    system_wide_config_file = join('/etc', basename)
+    user_config_file = join(default_data_path(), basename)
+    options_config_file = options_tmp_path()
+    in_order_config_files = [system_wide_config_file, user_config_file, options_config_file]
+    for config_file in in_order_config_files:
+        config_parser.read(config_file)
+
+
+def _data_path(absolute_path=None):
+    '''
+    Used to set constant DATA_FOLDER.
+    '''
+    if absolute_path:
+        if os.path.isabs(absolute_path):
+            return absolute_path
+
+    return default_data_path()
+
+def _openbazaard_node_port(port=None, testnet=None):
+    '''
+    Port used for node to node communication.
+    '''
+    if port:
+        return port
+    dif testnet:
+        return 28467
+    return 18467
 
 
 cfg = ConfigParser(DEFAULTS)

--- a/db/datastore.py
+++ b/db/datastore.py
@@ -23,6 +23,10 @@ class Database(object):
         _initialize_datafolder_tree()
         _initialize_database(DATABASE)
 
+    # temporary, we wont need this if TESTNET in constants works
+    def path(self):
+        return self._database
+
     class HashMap(object):
         """
         Creates a table in the database for mapping file hashes (which are sent

--- a/openbazaard.py
+++ b/openbazaard.py
@@ -1,5 +1,4 @@
-__author__ = 'chris'
-
+__author__ = 'chris', 'tobin'
 import argparse
 import platform
 import requests
@@ -250,8 +249,35 @@ commands:
                 description="Restart the server",
                 usage='''usage:
         python openbazaard.py restart''')
-            parser.parse_args(sys.argv[2:])
-            print "Restarting OpenBazaar server..."
-            self.daemon.restart()
+
+        if len(sys.argv) > 1:
+            warning = 'Warning: restart does not accept options'
+            warning += ', manually stop then start server instead.'
+            print warning
+        print "Restarting OpenBazaar server..."
+        self.stop()
+        self.start()
+
+def _write_args_to_file(args):
+    '''
+    Write command line options to file.
+
+    File is temporary and in format accepted by ConfigParser
+    '''
+    path = options_tmp_path()
+    if isfile(path):
+        os.remove(path)
+    f = open(path, 'w')
+    print >>f, '[CONSTANTS]'
+
+    for arg in vars(args):
+        config_string = arg + ' = ' + str(getattr(args, arg))
+        print >>f, config_string
+
+    f.close()
+
+
+if __name__ == '__main__':
+    Parser()
 
     Parser(OpenBazaard('/tmp/openbazaard.pid'))

--- a/platform_agnostic.py
+++ b/platform_agnostic.py
@@ -1,0 +1,70 @@
+'''Platform agnostic functions.'''
+from platform import platform
+import os
+from os.path import expanduser, join
+
+#
+# Omission: the 'free' BSD's are not covered here
+#
+
+OPTIONS_TMP_FILE = 'openbazaard_options.tmp'
+
+def is_unixlike():
+    if is_linux() or is_osx():
+        return True
+    return False
+
+
+def is_windows():
+    which_os = platform(aliased=True, terse=True).lower()
+    return 'window' in which_os
+
+
+def is_linux():
+    which_os = platform(aliased=True, terse=True).lower()
+    return 'linux' in which_os
+
+
+def is_osx():
+    which_os = platform(aliased=True, terse=True).lower()
+    return 'darwin' in which_os
+
+
+def options_tmp_path():
+    return '/tmp/' + OPTIONS_TMP_FILE
+
+
+# see issue  #163
+def default_data_path():
+    '''
+    Try to fit in with platform file naming conventions.
+    '''
+    if is_osx():
+        return join(home_path(), 'Library', 'Application Support', 'OpenBazzar')
+    elif is_linux():
+        return join(home_path(), '.openbazaar')
+
+    return join(home_path(), 'OpenBazaar')
+
+
+def home_path():
+    if is_windows():
+        return os.environ['HOMEPATH']
+    if is_unixlike():
+        return expanduser('~')
+
+    error = 'Cannot determine home path for your platform'
+    error += ', please report this to OpenBazaar so we can fix it.'
+    error += '  Thank you for your patience.'
+    raise RuntimeError(error)
+
+
+
+
+if __name__ == '__main__':
+    is_linux()
+    is_windows()
+    is_osx()
+    if is_linux():
+        assert not is_windows()
+        assert not is_osx()


### PR DESCRIPTION
Proof of concept only, do not merge. Here I have attempted to consolidate consants out of openbazaard.py and into constants.py. Also moved platform_agnostic functions to their own file. I tried to refactor openbazaard.py as little as possible so it is easier to see what I have done. Howevere I moved Openbazaard class into daemon.py so it could import a constant. The point of this PR is a to open a discussion about wheather these are the correct techniques to use. Cheers