### PR TITLE
Enable platform specific data_folder name/location

### DIFF
--- a/config.py
+++ b/config.py
@@ -23,7 +23,7 @@ for i in range(2):
 
 DEFAULTS = {
     # Default project config file may now remove these items
-    'data_folder': 'OpenBazaar',  # FIXME change to 'None' when issue #163 is resolved
+    'data_folder': None,
     'ksize': '20',
     'alpha': '3',
     'transaction_fee': '10000',


### PR DESCRIPTION
Resolves issue #163. This breaks current DATA_FOLDER location. Running instances will need to set location in config file or rename folder.