### PR TITLE
BUGFIX: Use WSPORT instead of RESTPORT for SSL websockets.

### DIFF
--- a/openbazaard.py
+++ b/openbazaard.py
@@ -117,7 +117,7 @@ def run(*args):
     # websockets api
     ws_api = WSFactory(mserver, kserver, only_ip=ALLOWIP)
     if SSL:
-        reactor.listenSSL(RESTPORT, WebSocketFactory(ws_api),
+        reactor.listenSSL(WSPORT, WebSocketFactory(ws_api),
                           ChainedOpenSSLContextFactory(SSL_KEY, SSL_CERT), interface=interface)
     else:
         reactor.listenTCP(WSPORT, WebSocketFactory(ws_api), interface=interface)


### PR DESCRIPTION
I think this should use WSPORT instead of RESTPORT for this portion. Found it while testing SSL.