### PR TITLE
Added platform Independent utility functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SCRIPTS=./scripts
-TESTPATH=./dht/tests ./db/tests ./market/tests
+TESTPATH=./dht/tests ./db/tests ./market/tests ./utils/tests
 
 .PHONY: all unittest check
 

--- a/config.py
+++ b/config.py
@@ -1,16 +1,13 @@
-'''Parses configuration file and sets project wide constants.
+"""Parses configuration file and sets project wide constants."""
 
-This file has intrinsic naming difficulties because it is trying to be platform
-agnostic but naming variables is inherently platform specific (i.e directory vs
-folder)
-'''
-__author__ = 'foxcarlos-TeamCreed', 'Tobin Harding'
+__author__ = 'foxcarlos-TeamCreed', 'tobin'
 
 import os
-from platform import platform
-from os.path import expanduser, join, isfile
+from os.path import join, isfile
 from ConfigParser import ConfigParser
 from urlparse import urlparse
+
+from utils.platform_independant import data_path
 
 PROTOCOL_VERSION = 13
 CONFIG_FILE = join(os.getcwd(), 'ob.cfg')
@@ -22,8 +19,7 @@ for i in range(2):
         CONFIG_FILE = join(paths[0], paths[2])
 
 DEFAULTS = {
-    # Default project config file may now remove these items
-    'data_folder': 'OpenBazaar',  # FIXME change to 'None' when issue #163 is resolved
+    'data_folder': None,
     'ksize': '20',
     'alpha': '3',
     'transaction_fee': '10000',
@@ -38,74 +34,8 @@ DEFAULTS = {
     'seed': 'seed.openbazaar.org:8080,5b44be5c18ced1bc9400fe5e79c8ab90204f06bebacc04dd9c70a95eaca6e117',
 }
 
-
-def _platform_agnostic_data_path(data_folder):
-    '''
-    Create absolute path name, exported as DATA_FOLDER.
-
-    User may configure using relative path, absolute path or use default.
-      Relative path puts named folder in users home directory.
-      Absolute path uses (obviously) the named absolute path.
-      Default is currently to use 'OpenBazaar' in home directory.
-
-    See issue #163
-    '''
-    if data_folder:
-        if os.path.isabs(data_folder):
-            return data_folder
-
-    return join(_platform_agnostic_home_path(), _platform_agnostic_data_folder(data_folder), '')
-
-
-def _platform_agnostic_home_path():
-    home_path = ''
-    if _is_windows():
-        home_path = os.environ['HOMEPATH'] # Does this work for versions before Windows 7?
-    else:
-        home_path = expanduser('~')
-
-    return home_path
-
-
-# see issue  #163
-def _platform_agnostic_data_folder(data_folder):
-    '''
-    Try to fit in with platform file naming conventions.
-    '''
-    if data_folder:
-        return data_folder
-
-    name = ''
-    if _is_osx():
-        name = join('Library', 'Application Support', 'OpenBazaar')
-    elif _is_linux():
-        name = '.openbazaar'
-    else:                       # TODO add clauses for Windows, and BSD
-        name = 'OpenBazaar'
-
-    return name
-
-
-def _is_windows():
-    which_os = platform(aliased=True, terse=True).lower()
-    return 'window' in which_os
-
-
-def _is_linux():
-    which_os = platform(aliased=True, terse=True).lower()
-    return 'linux' in which_os
-
-
-def _is_osx():
-    which_os = platform(aliased=True, terse=True).lower()
-    return 'darwin' in which_os
-
-
 def _is_well_formed_seed_string(string):
-    '''
-    Parse string url:port,key
-
-    '''
+    """Parse string url:port,key."""
     if ',' in string:
         url, key = string.split(',')
         parsed = urlparse(url)
@@ -134,10 +64,18 @@ def _is_seed_tuple(tup):
 
 
 def _tuple_from_seed_string(string):
-    '''
-    Accepts well formed seed string, returns tuple (url:port, key)
-    '''
+    """Accepts well formed seed string, returns tuple (url:port, key)."""
     return tuple(string.split(','))
+
+
+def _is_well_formed_data_path(path):
+    """Path is well formed if absolute and it exists."""
+    if path:
+        if os.path.isabs(path):
+            if os.path.exists(path):
+                return True
+
+    return False
 
 
 cfg = ConfigParser(DEFAULTS)
@@ -147,7 +85,13 @@ if isfile(CONFIG_FILE):
 else:
     print 'Warning: configuration file not found: (%s), using default values' % CONFIG_FILE
 
-DATA_FOLDER = _platform_agnostic_data_path(cfg.get('CONSTANTS', 'DATA_FOLDER'))
+DATA_FOLDER = ''
+config_data_path = cfg.get('CONSTANTS', 'DATA_FOLDER')
+if _is_well_formed_data_path(config_data_path):
+    DATA_FOLDER = join(config_data_path, '')
+else:
+    DATA_FOLDER = data_path()
+
 KSIZE = int(cfg.get('CONSTANTS', 'KSIZE'))
 ALPHA = int(cfg.get('CONSTANTS', 'ALPHA'))
 TRANSACTION_FEE = int(cfg.get('CONSTANTS', 'TRANSACTION_FEE'))
@@ -186,16 +130,16 @@ if __name__ == '__main__':
         well_formed = 'seed.openbazaar.org:8080,5b44be5c18ced1bc9400fe5e79c8ab90204f06bebacc04dd9c70a95eaca6e117'
         # test ill-formed url's (build fails with pylint error if we use long/descriptive names
         # key too short
-#        bad_1 = 'seed.openbazaar.org:8080,5b44be5c18ced1bc9400fe5e79'
+        # bad_1 = 'seed.openbazaar.org:8080,5b44be5c18ced1bc9400fe5e79'
         # no port number
-#        bad_2 = 'seed.openbazaar.org,5b44be5c18ced1bc9400fe5e79c8ab90204f06bebacc04dd9c70a95eaca6e117'
+        # bad_2 = 'seed.openbazaar.org,5b44be5c18ced1bc9400fe5e79c8ab90204f06bebacc04dd9c70a95eaca6e117'
         # no host name in url
-#        bad_3 = 'openbazaar.org:8080,5b44be5c18ced1bc9400fe5e79c8ab90204f06bebacc04dd9c70a95eaca6e117'
+        # bad_3 = 'openbazaar.org:8080,5b44be5c18ced1bc9400fe5e79c8ab90204f06bebacc04dd9c70a95eaca6e117'
 
         assert _is_well_formed_seed_string(well_formed)
-#        assert not _is_well_formed_seed_string(b1)
-#        assert not _is_well_formed_seed_string(b2)
-#        assert not _is_well_formed_seed_string(b3)
+        # assert not _is_well_formed_seed_string(b1)
+        # assert not _is_well_formed_seed_string(b2)
+        # assert not _is_well_formed_seed_string(b3)
 
     def test_is_seed_tuple():
         good = ('seed.openbazaar.org:8080', '5b44be5c18ced1bc9400fe5e79c8ab90204f06bebacc04dd9c70a95eaca6e117')
@@ -205,13 +149,6 @@ if __name__ == '__main__':
         assert not _is_seed_tuple(bad_not_tuple)
         assert not _is_seed_tuple(bad_not_seed_tuple)
 
-
-    _is_linux()
-    _is_windows()
-    _is_osx()
-    if _is_linux():
-        assert not _is_windows()
-        assert not _is_osx()
 
     test_is_well_formed_seed_string()
     test_is_seed_tuple()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'chris'

--- a/utils/platform_independant.py
+++ b/utils/platform_independant.py
@@ -1,0 +1,65 @@
+"""Platform independant utility functions."""
+__author__ = 'tobin'
+
+from os import environ
+from os.path import expanduser, join
+from platform import platform
+
+def is_windows():
+    """Are we on a Windows platform."""
+    which_os = platform(aliased=True, terse=True).lower()
+    return 'window' in which_os
+
+
+def is_linux():
+    """Are we on a Linux platform."""
+    which_os = platform(aliased=True, terse=True).lower()
+    return 'linux' in which_os
+
+
+def is_osx():
+    """Are we on the OS X platform."""
+    which_os = platform(aliased=True, terse=True).lower()
+    return 'darwin' in which_os
+
+def is_unix_like():
+    """Are we on a Unix-like platform."""
+    return is_osx() or is_linux()
+
+
+def is_bsd():
+    """We should really support BSD as well."""
+    pass
+
+
+def home_path():
+    """Determine system home path."""
+    path = ''
+    if is_windows():
+        path = environ['HOMEPATH']
+    else:
+        path = expanduser('~')
+
+    return path
+
+
+def data_path():
+    """
+    Create absolute path name.
+
+    This is used to set DATA_FOLDER if it is not configured by user.
+    """
+    return join(home_path(), _data_folder())
+
+
+def _data_folder():
+    """Try to fit in with platform file naming conventions."""
+    name = ''
+    if is_osx():
+        name = join('Library', 'Application Support', 'OpenBazaar')
+    elif is_linux():
+        name = '.openbazaar'
+    else:                       # TODO add clauses for Windows, and BSD
+        name = 'OpenBazaar'
+
+    return join(name, '')

--- a/utils/tests/test_utils.py
+++ b/utils/tests/test_utils.py
@@ -1,0 +1,25 @@
+import unittest
+
+from utils.platform_independant import is_linux, is_osx, is_unix_like, is_windows
+
+
+def test_platform_predicates():
+    is_linux()
+    is_windows()
+    is_osx()
+    is_unix_like()
+
+    if is_linux():
+        assert is_unix_like()
+        assert not is_windows()
+        assert not is_osx()
+
+    if is_osx():
+        assert is_unix_like()
+        assert not is_windows()
+        assert not is_linux()
+
+    if is_windows():
+        assert not is_linux()
+        assert not is_osx()
+        assert not is_unix_like()


### PR DESCRIPTION
Some constants need to be determined in a platform independent manner. This patch adds this functionality to OpenBazaar. Added a new directory so as not to clutter up the root directory and also add tests. Moving these functions to a separate file also cleans up constants.py. platform_independant.py is so named because of library already having 'platorm'. A better name may exist.