### PR TITLE
Added platform Independent utility functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SCRIPTS=./scripts
-TESTPATH=./dht/tests ./db/tests ./market/tests
+TESTPATH=./dht/tests ./db/tests ./market/tests ./utils/tests
 
 .PHONY: all unittest check
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'chris'

--- a/utils/platform_independent.py
+++ b/utils/platform_independent.py
@@ -1,0 +1,65 @@
+"""Platform independent utility functions."""
+__author__ = 'tobin'
+
+from os import environ
+from os.path import expanduser, join
+from platform import platform
+
+def is_windows():
+    """Are we on a Windows platform."""
+    which_os = platform(aliased=True, terse=True).lower()
+    return 'window' in which_os
+
+
+def is_linux():
+    """Are we on a Linux platform."""
+    which_os = platform(aliased=True, terse=True).lower()
+    return 'linux' in which_os
+
+
+def is_osx():
+    """Are we on the OS X platform."""
+    which_os = platform(aliased=True, terse=True).lower()
+    return 'darwin' in which_os
+
+def is_unix_like():
+    """Are we on a Unix-like platform."""
+    return is_osx() or is_linux()
+
+
+def is_bsd():
+    """We should really support BSD as well."""
+    pass
+
+
+def home_path():
+    """Determine system home path."""
+    path = ''
+    if is_windows():
+        path = environ['HOMEPATH']
+    else:
+        path = expanduser('~')
+
+    return path
+
+
+def data_path():
+    """
+    Create absolute path name.
+
+    This is used to set DATA_FOLDER if it is not configured by user.
+    """
+    return join(home_path(), _data_folder())
+
+
+def _data_folder():
+    """Try to fit in with platform file naming conventions."""
+    name = ''
+    if is_osx():
+        name = join('Library', 'Application Support', 'OpenBazaar')
+    elif is_linux():
+        name = '.openbazaar'
+    else:                       # TODO add clauses for Windows, and BSD
+        name = 'OpenBazaar'
+
+    return join(name, '')

--- a/utils/tests/test_utils.py
+++ b/utils/tests/test_utils.py
@@ -1,0 +1,30 @@
+import unittest
+
+from utils.platform_independent import is_linux, is_osx, is_unix_like, is_windows
+
+
+class UtilsPlatformIndependant(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_platform_predicates(self):
+        is_linux()
+        is_windows()
+        is_osx()
+        is_unix_like()
+
+        if is_linux():
+            self.assertTrue(is_unix_like())
+            self.assertFalse(is_windows())
+            self.assertFalse(is_osx())
+
+        if is_osx():
+            self.assertTrue(is_unix_like())
+            self.assertFalse(is_windows())
+            self.assertFalse(is_linux())
+
+        if is_windows():
+            self.assertFalse(is_linux())
+            self.assertFalse(is_osx())
+            self.assertFalse(is_unix_like())


### PR DESCRIPTION
Some constants need to be determined in a platform independent manner. This patch adds this functionality to OpenBazaar. Added a new directory so as not to clutter up the root directory and also add tests. Moving these functions to a separate file also cleans up constants.py. platform_independent.py is so named because of library already having 'platform'. A better name may exist. Now wit object-oriented testing in place.