### PR TITLE
Fixed multiple load of seeds

### DIFF
--- a/config.py
+++ b/config.py
@@ -166,7 +166,9 @@ for item in items:
     if _is_seed_tuple(item):
         seed = item[1]
         if _is_well_formed_seed_string(seed):
-            SEEDS.append(_tuple_from_seed_string(seed))
+            new_seed = _tuple_from_seed_string(seed)
+            if new_seed not in SEEDS:
+                SEEDS.append(new_seed)
         else:
             print 'Warning: please check your configuration file: %s' % seed
 


### PR DESCRIPTION
Identical seeds in config file and config.py:defaults cause seed to be appended twice. Added check to see if seed was already present before adding it to SEEDS.