### PR TITLE
Initiated system management support

### DIFF
--- a/service_mgmt/README.md
+++ b/service_mgmt/README.md
@@ -1,0 +1,4 @@
+System Management
+=================
+
+Tools for running OpenBazaard as a daemon using Systemd (and Launchd)

--- a/service_mgmt/systemd/openbazaard.conf
+++ b/service_mgmt/systemd/openbazaard.conf
@@ -1,0 +1,2 @@
+# install in /usr/lib/tmpfiles.d/openbazaar.conf
+D /run/openbazaar 0755 root root

--- a/service_mgmt/systemd/openbazaard.service
+++ b/service_mgmt/systemd/openbazaard.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=OpenBazaar Server
+
+[Service]
+# Set path to openbazaard
+Environment=OB_PATH=/home/tobin/build/github/openbazaar/server/openbazaard.py
+Environment=OB_START=start -t'
+
+# Set path to Python 2 (remember virtual environment if you use one)
+ExecStart=/home/tobin/build/github/openbazaar/venv/bin/python $OB_PATH $OB_START
+
+#Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This patch adds systemd support for running OpenBazaar as a daemon. Has bug that config file is not found (because systemd does not run ob from within the repo directory). This bug is unrelated to systemd support however.