### PR TITLE
Enable system wide constans by removing command line options

### DIFF
--- a/api/restapi.py
+++ b/api/restapi.py
@@ -23,6 +23,7 @@ from protos.countries import CountryCode
 from protos import objects
 from keys import blockchainid
 from keys.keychain import KeyChain
+from keys.credentials import get_credentials
 from dht.utils import digest
 from market.profile import Profile
 from market.contracts import Contract
@@ -57,16 +58,15 @@ class OpenBazaarAPI(APIResource):
                 return server.NOT_DONE_YET
         return wraps(func)(_authenticate)
 
-    def __init__(self, mserver, kserver, protocol, username, password, authenticated_sessions):
+    def __init__(self, mserver, kserver, protocol, authenticated_sessions):
         self.mserver = mserver
         self.kserver = kserver
         self.protocol = protocol
-        self.db = mserver.db
+        self.db = Database()
         self.keychain = KeyChain(self.db)
-        self.username = username
-        self.password = password
         self.authenticated_sessions = authenticated_sessions
         self.failed_login_attempts = {}
+
         task.LoopingCall(self._keep_sessions_alive).start(890, False)
         APIResource.__init__(self)
 
@@ -90,7 +90,8 @@ class OpenBazaarAPI(APIResource):
                         self.failed_login_attempts[request.getHost().host] >= 7:
             return json.dumps({"success": False, "reason": "too many attempts"})
         try:
-            if request.args["username"][0] == self.username and request.args["password"][0] == self.password:
+            username, password = get_credentials()
+            if request.args["username"][0] == username and request.args["password"][0] == password:
                 self.authenticated_sessions.append(request.getSession())
                 if request.getHost().host in self.failed_login_attempts:
                     del self.failed_login_attempts[request.getHost().host]
@@ -1304,11 +1305,11 @@ class OpenBazaarAPI(APIResource):
 
 class RestAPI(Site):
 
-    def __init__(self, mserver, kserver, openbazaar_protocol, username, password,
+    def __init__(self, mserver, kserver, openbazaar_protocol,
                  authenticated_sessions, only_ip="127.0.0.1", timeout=60 * 60 * 1):
         self.only_ip = only_ip
         api_resource = OpenBazaarAPI(mserver, kserver, openbazaar_protocol,
-                                     username, password, authenticated_sessions)
+                                     authenticated_sessions)
         Site.__init__(self, api_resource, timeout=timeout)
 
     def buildProtocol(self, addr):

--- a/api/restapi.py
+++ b/api/restapi.py
@@ -18,7 +18,8 @@ from twisted.internet import defer, reactor, task
 from twisted.protocols.basic import FileSender
 
 from config import DATA_FOLDER, RESOLVER, LIBBITCOIN_SERVER_TESTNET, LIBBITCOIN_SERVER, \
-    set_value, get_value, str_to_bool
+    ALLOWIP, set_value, get_value, str_to_bool
+    
 from protos.countries import CountryCode
 from protos import objects
 from keys import blockchainid
@@ -28,6 +29,7 @@ from dht.utils import digest
 from market.profile import Profile
 from market.contracts import Contract
 from net.upnp import PortMapper
+from db.datastore import Database
 
 DEFAULT_RECORDS_COUNT = 20
 DEFAULT_RECORDS_OFFSET = 0
@@ -63,7 +65,7 @@ class OpenBazaarAPI(APIResource):
         self.kserver = kserver
         self.protocol = protocol
         self.db = Database()
-        self.keychain = KeyChain(self.db)
+        self.keychain = KeyChain()
         self.authenticated_sessions = authenticated_sessions
         self.failed_login_attempts = {}
 
@@ -1306,8 +1308,8 @@ class OpenBazaarAPI(APIResource):
 class RestAPI(Site):
 
     def __init__(self, mserver, kserver, openbazaar_protocol,
-                 authenticated_sessions, only_ip="127.0.0.1", timeout=60 * 60 * 1):
-        self.only_ip = only_ip
+                 authenticated_sessions, timeout=60 * 60 * 1):
+        self.only_ip = ALLOWIP
         api_resource = OpenBazaarAPI(mserver, kserver, openbazaar_protocol,
                                      authenticated_sessions)
         Site.__init__(self, api_resource, timeout=timeout)

--- a/api/ws.py
+++ b/api/ws.py
@@ -7,7 +7,10 @@ import os
 import time
 import nacl.signing
 import nacl.encoding
-from config import DATA_FOLDER
+from twisted.internet.protocol import Protocol, Factory, connectionDone
+from txws import WebSocketProtocol, WebSocketFactory
+
+from config import DATA_FOLDER, ALLOWIP
 from market.profile import Profile
 from keys.keychain import KeyChain
 from random import shuffle
@@ -16,8 +19,8 @@ from protos.objects import PlaintextMessage, Value, Listings
 from protos import objects
 from binascii import unhexlify
 from dht.node import Node
-from twisted.internet.protocol import Protocol, Factory, connectionDone
-from txws import WebSocketProtocol, WebSocketFactory
+from db.datastore import Database
+
 
 ALLOWED_TAGS = ('h2', 'h3', 'h4', 'h5', 'h6', 'p', 'a', 'u', 'ul', 'ol', 'nl', 'li', 'b', 'i', 'strong',
                 'em', 'strike', 'hr', 'br', 'img', 'blockquote')
@@ -282,14 +285,14 @@ class WSProtocol(Protocol):
 
 class WSFactory(Factory):
 
-    def __init__(self, mserver, kserver, only_ip="127.0.0.1"):
+    def __init__(self, mserver, kserver):
         self.mserver = mserver
         self.kserver = kserver
-        self.db = mserver.db
+        self.db = Database()
         self.outstanding_listings = {}
         self.outstanding_vendors = {}
         self.protocol = WSProtocol
-        self.only_ip = only_ip
+        self.only_ip = ALLOWIP
         self.clients = []
 
     def buildProtocol(self, addr):

--- a/config.py
+++ b/config.py
@@ -14,6 +14,9 @@ from urlparse import urlparse
 
 PROTOCOL_VERSION = 13
 CONFIG_FILE = join(os.getcwd(), 'ob.cfg')
+TESTNET_PORT = 28467
+MAINNET_PORT = 18467
+
 
 # FIXME probably a better way to do this. This curretly checks two levels deep
 for i in range(2):
@@ -30,6 +33,12 @@ DEFAULTS = {
     'libbitcoin_server': 'tcp://libbitcoin1.openbazaar.org:9091',
     'libbitcoin_server_testnet': 'tcp://libbitcoin2.openbazaar.org:9091',
     'resolver': 'http://resolver.onename.com/',
+    'testnet': 'True',
+    'loglevel': 'info',
+    'allowip': '127.0.0.1',
+    'restport': '18460',
+    'wsport': '18466',
+    'heartbeatport': '18470',
     'ssl_cert': None,
     'ssl_key': None,
     'ssl': False,
@@ -165,11 +174,21 @@ TRANSACTION_FEE = int(cfg.get('CONSTANTS', 'TRANSACTION_FEE'))
 LIBBITCOIN_SERVER = cfg.get('CONSTANTS', 'LIBBITCOIN_SERVER')
 LIBBITCOIN_SERVER_TESTNET = cfg.get('CONSTANTS', 'LIBBITCOIN_SERVER_TESTNET')
 RESOLVER = cfg.get('CONSTANTS', 'RESOLVER')
+TESTNET = str_to_bool(cfg.get('CONSTANTS', 'TESTNET'))
+PORT = MAINNET_PORT if not TESTNET else TESTNET_PORT
+LOGLEVEL = cfg.get('CONSTANTS', 'LOGLEVEL')
+ALLOWIP = cfg.get('CONSTANTS', 'ALLOWIP')
+RESTPORT = int(cfg.get('CONSTANTS', 'RESTPORT'))
+WSPORT = int(cfg.get('CONSTANTS', 'WSPORT'))
+HEARTBEATPORT = int(cfg.get('CONSTANTS', 'HEARTBEATPORT'))
+
 SSL = str_to_bool(cfg.get('AUTHENTICATION', 'SSL'))
 SSL_CERT = cfg.get('AUTHENTICATION', 'SSL_CERT')
 SSL_KEY = cfg.get('AUTHENTICATION', 'SSL_KEY')
 USERNAME = cfg.get('AUTHENTICATION', 'USERNAME')
 PASSWORD = cfg.get('AUTHENTICATION', 'PASSWORD')
+
+
 SEEDS = []
 
 items = cfg.items('SEEDS')  # this also includes items in DEFAULTS

--- a/daemon.py
+++ b/daemon.py
@@ -64,7 +64,7 @@ class Daemon(object):
     def delpid(self):
         os.remove(self.pidfile)
 
-    def start(self, *args):
+    def start(self):
         """
         Start the daemon
         """
@@ -83,7 +83,7 @@ class Daemon(object):
 
         # Start the daemon
         self.daemonize()
-        self.run(*args)
+        self.run()
 
     def stop(self):
         """
@@ -123,7 +123,7 @@ class Daemon(object):
         self.stop()
         self.start()
 
-    def run(self, *args):
+    def run(self):
         """
         You should override this method when you subclass Daemon. It will be called after the process has been
         daemonized by start() or restart().

--- a/db/datastore.py
+++ b/db/datastore.py
@@ -839,9 +839,7 @@ def _initialize_database(database):
 
 
 def _initialize_datafolder_tree():
-    '''
-    Creates, if not present, directory tree in DATA_FOLDER.
-    '''
+    """Creates, if not present, directory tree in DATA_FOLDER."""
     tree = [
         ['cache'],
         ['store', 'contracts', 'listings'],

--- a/db/datastore.py
+++ b/db/datastore.py
@@ -3,7 +3,7 @@ __author__ = 'chris'
 import os
 import sqlite3 as lite
 from collections import Counter
-from config import DATA_FOLDER
+from config import DATA_FOLDER, TESTNET
 from dht.node import Node
 from dht.utils import digest
 from protos import objects
@@ -16,10 +16,10 @@ class Database(object):
     # pylint: disable=W0601
     DATABASE = None
 
-    def __init__(self, testnet=False, filepath=None):
+    def __init__(self, filepath=None):
         global DATABASE
 
-        DATABASE = _database_path(testnet, filepath)
+        DATABASE = _database_path(filepath)
         _initialize_datafolder_tree()
         _initialize_database(DATABASE)
 
@@ -812,19 +812,13 @@ refundPolicy, moderatorList) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)''',
             return cursor.fetchone()
 
 
-def _database_path(testnet, filepath):
-    '''
-    Get database pathname.
-
-    Args:
-      testnet: Boolean
-      filename: If provided, overrides testnet
-    '''
+def _database_path(filepath):
+    """Get database pathname."""
     path = ''
 
     if filepath:
         path = filepath
-    elif testnet:
+    elif TESTNET:
         path = join(DATA_FOLDER, "OB-Testnet.db")
     else:
         path = join(DATA_FOLDER, "OB-Mainnet.db")
@@ -833,9 +827,7 @@ def _database_path(testnet, filepath):
 
 
 def _initialize_database(database):
-    '''
-    Create database, if not present, and clear cache.
-    '''
+    """Create database, if not present, and clear cache."""
     if not database:
         raise RuntimeError('attempted to initialize empty path')
 

--- a/dht/protocol.py
+++ b/dht/protocol.py
@@ -22,13 +22,12 @@ from protos.message import PING, STUN, STORE, DELETE, FIND_NODE, FIND_VALUE, HOL
 class KademliaProtocol(RPCProtocol):
     implements(MessageProcessor)
 
-    def __init__(self, sourceNode, storage, ksize, database, signing_key):
+    def __init__(self, sourceNode, storage, ksize, signing_key):
         self.ksize = ksize
         self.router = RoutingTable(self, ksize, sourceNode)
         self.storage = storage
         self.sourceNode = sourceNode
         self.multiplexer = None
-        self.db = database
         self.signing_key = signing_key
         self.log = Logger(system=self)
         self.handled_commands = [PING, STUN, STORE, DELETE, FIND_NODE, FIND_VALUE, HOLE_PUNCH, INV, VALUES]

--- a/keys/credentials.py
+++ b/keys/credentials.py
@@ -3,8 +3,11 @@ import random
 from config import USERNAME, PASSWORD
 from hashlib import sha256
 
+from db.datastore import Database
 
-def get_credentials(database):
+
+def get_credentials():
+    database = Database()
     settings = database.Settings()
     creds = settings.get_credentials()
     if creds == (USERNAME, PASSWORD):

--- a/keys/keychain.py
+++ b/keys/keychain.py
@@ -3,18 +3,19 @@ import bitcointools
 import nacl.signing
 import nacl.encoding
 import threading
+
 from keys.guid import GUID
+from db.datastore import Database
 
 
 class KeyChain(object):
 
-    def __init__(self, database, callback=None, heartbeat_server=None):
-        self.db = database
-        self.keystore = database.KeyStore()
+    def __init__(self, callback=None):
+        """If GUID's are not present, must be called with callback."""
+        self.keystore = Database().KeyStore()
         guid_keys = self.keystore.get_key("guid")
         if guid_keys is None:
-            heartbeat_server.set_status("generating GUID")
-            threading.Thread(target=self.create_keychain, args=[callback, heartbeat_server]).start()
+            threading.Thread(target=self.create_keychain, args=[callback]).start()
         else:
             g = GUID.from_privkey(guid_keys[0])
             self.guid = g.guid
@@ -27,24 +28,27 @@ class KeyChain(object):
             if callback is not None:
                 callback(self)
 
-    def create_keychain(self, callback, heartbeat_server):
+    def create_keychain(self, callback):
         """
         The guid generation can take a while. While it's doing that we will
         open a port to allow a UI to connect and listen for generation to
         complete.
         """
+
+        heartbeat_server = HeartbeatFactory()
+        heartbeat_server.set_status("generating GUID")
+
         print "Generating GUID, this may take a few minutes..."
-        keystore = self.db.KeyStore()
         g = GUID()
         self.guid = g.guid
         self.signing_key = g.signing_key
         self.verify_key = g.verify_key
-        keystore.set_key("guid", self.signing_key.encode(encoder=nacl.encoding.HexEncoder),
+        self.keystore.set_key("guid", self.signing_key.encode(encoder=nacl.encoding.HexEncoder),
                          self.verify_key.encode(encoder=nacl.encoding.HexEncoder))
 
         self.bitcoin_master_privkey = bitcointools.bip32_master_key(bitcointools.sha256(self.signing_key.encode()))
         self.bitcoin_master_pubkey = bitcointools.bip32_privtopub(self.bitcoin_master_privkey)
-        keystore.set_key("bitcoin", self.bitcoin_master_privkey, self.bitcoin_master_pubkey)
+        self.keystore.set_key("bitcoin", self.bitcoin_master_privkey, self.bitcoin_master_pubkey)
 
         self.encryption_key = self.signing_key.to_curve25519_private_key()
         self.encryption_pubkey = self.verify_key.to_curve25519_public_key()

--- a/log.py
+++ b/log.py
@@ -3,7 +3,7 @@ Copyright (c) 2014 Brian Muller
 """
 
 import sys
-from twisted.python import log
+from twisted.python import log, logfile
 
 DEBUG = 5
 WARNING = 4
@@ -11,11 +11,21 @@ INFO = 3
 ERROR = 2
 CRITICAL = 1
 
-levels = {"debug": 5, "warning": 4, "info": 3, "error": 2, "critical": 1}
+levels = {
+    "debug": DEBUG,
+    "warning": WARNING,
+    "info": INFO,
+    "error": ERROR,
+    "critical": CRITICAL
+}
 
 class FileLogObserver(log.FileLogObserver):
-    def __init__(self, f=None, level="info", default=DEBUG):
-        log.FileLogObserver.__init__(self, f or sys.stdout)
+    def __init__(self, log_file=None, level="info", default=DEBUG):
+        if log_file:
+            fout = logfile.LogFile.fromFullPath(log_file, rotateLength=15000000, maxRotatedFiles=1)
+        else:
+            fout = sys.stdout
+        log.FileLogObserver.__init__(self, fout)
         self.level = levels[level]
         self.default = default
 

--- a/market/contracts.py
+++ b/market/contracts.py
@@ -1252,11 +1252,12 @@ class Contract(object):
         return json.dumps(self.contract, indent=4)
 
 
-def check_unfunded_for_payment(db, libbitcoin_client, notification_listener, testnet=False):
+def check_unfunded_for_payment(libbitcoin_client, notification_listener):
     """
     Run through the unfunded contracts in our database and query the
     libbitcoin server to see if they received a payment.
     """
+    db = Database()
     def check(order_id):
         try:
             if os.path.exists(DATA_FOLDER + "purchases/unfunded/" + order_id[0] + ".json"):

--- a/market/listeners.py
+++ b/market/listeners.py
@@ -8,6 +8,7 @@ from interfaces import MessageListener, BroadcastListener, NotificationListener
 from zope.interface import implements
 from protos.objects import PlaintextMessage, Following
 from dht.utils import digest
+from db.datastore import Database
 
 ALLOWED_TAGS = ('h2', 'h3', 'h4', 'h5', 'h6', 'p', 'a', 'u', 'ul', 'ol', 'nl', 'li', 'b', 'i', 'strong',
                 'em', 'strike', 'hr', 'br', 'img', 'blockquote')
@@ -16,9 +17,9 @@ ALLOWED_TAGS = ('h2', 'h3', 'h4', 'h5', 'h6', 'p', 'a', 'u', 'ul', 'ol', 'nl', '
 class MessageListenerImpl(object):
     implements(MessageListener)
 
-    def __init__(self, web_socket_factory, database):
+    def __init__(self, web_socket_factory):
         self.ws = web_socket_factory
-        self.db = database.MessageStore()
+        self.db = Database().MessageStore()
 
     def notify(self, plaintext, signature):
         try:
@@ -49,9 +50,9 @@ class MessageListenerImpl(object):
 class BroadcastListenerImpl(object):
     implements(BroadcastListener)
 
-    def __init__(self, web_socket_factory, database):
+    def __init__(self, web_socket_factory):
         self.ws = web_socket_factory
-        self.db = database
+        self.db = Database()
 
     def notify(self, guid, message):
         # pull the metadata for this node from the db
@@ -83,9 +84,9 @@ class BroadcastListenerImpl(object):
 class NotificationListenerImpl(object):
     implements(NotificationListener)
 
-    def __init__(self, web_socket_factory, database):
+    def __init__(self, web_socket_factory):
         self.ws = web_socket_factory
-        self.db = database
+        self.db = Database()
 
     def notify(self, guid, handle, notif_type, order_id, title, image_hash):
         timestamp = int(time.time())

--- a/market/profile.py
+++ b/market/profile.py
@@ -1,6 +1,8 @@
 __author__ = 'chris'
 import gnupg
+
 from protos import objects
+from db.datastore import Database
 
 
 class Profile(object):
@@ -11,9 +13,9 @@ class Profile(object):
     need to send it to our peers, we can just call get().
     """
 
-    def __init__(self, db):
+    def __init__(self):
         self.profile = objects.Profile()
-        self.db = db.ProfileStore()
+        self.db = Database().ProfileStore()
         if self.db.get_proto() is not None:
             self.profile.ParseFromString(self.db.get_proto())
 

--- a/market/protocol.py
+++ b/market/protocol.py
@@ -9,30 +9,32 @@ from collections import OrderedDict
 from interfaces import MessageProcessor, BroadcastListener, MessageListener, NotificationListener
 from keys.bip32utils import derive_childkey
 from log import Logger
-from market.contracts import Contract
-from market.moderation import process_dispute, close_dispute
-from market.profile import Profile
-from nacl.public import PublicKey, Box
-from net.rpcudp import RPCProtocol
-from protos.message import GET_CONTRACT, GET_IMAGE, GET_PROFILE, GET_LISTINGS, GET_USER_METADATA,\
-    GET_CONTRACT_METADATA, FOLLOW, UNFOLLOW, GET_FOLLOWERS, GET_FOLLOWING, BROADCAST, MESSAGE, ORDER, \
-    ORDER_CONFIRMATION, COMPLETE_ORDER, DISPUTE_OPEN, DISPUTE_CLOSE, GET_RATINGS, REFUND
 from protos.objects import Metadata, Listings, Followers, PlaintextMessage
 from zope.interface import implements
 from zope.interface.exceptions import DoesNotImplement
 from zope.interface.verify import verifyObject
+from nacl.public import PublicKey, Box
+
+from db.datastore import Database
+from market.contracts import Contract
+from market.moderation import process_dispute, close_dispute
+from market.profile import Profile
+from net.rpcudp import RPCProtocol
+from protos.message import GET_CONTRACT, GET_IMAGE, GET_PROFILE, GET_LISTINGS, GET_USER_METADATA,\
+    GET_CONTRACT_METADATA, FOLLOW, UNFOLLOW, GET_FOLLOWERS, GET_FOLLOWING, BROADCAST, MESSAGE, ORDER, \
+    ORDER_CONFIRMATION, COMPLETE_ORDER, DISPUTE_OPEN, DISPUTE_CLOSE, GET_RATINGS, REFUND
 
 
 class MarketProtocol(RPCProtocol):
     implements(MessageProcessor)
 
-    def __init__(self, node, router, signing_key, database):
+    def __init__(self, node, router, signing_key):
         self.router = router
         self.node = node
         RPCProtocol.__init__(self, node, router)
         self.log = Logger(system=self)
         self.multiplexer = None
-        self.db = database
+        self.db = Database()
         self.signing_key = signing_key
         self.listeners = []
         self.handled_commands = [GET_CONTRACT, GET_IMAGE, GET_PROFILE, GET_LISTINGS, GET_USER_METADATA,

--- a/net/heartbeat.py
+++ b/net/heartbeat.py
@@ -4,6 +4,7 @@ import json
 from twisted.internet.protocol import Protocol, Factory, connectionDone
 from twisted.internet.task import LoopingCall
 
+from config import ALLOWIP
 
 # pylint: disable=W0232
 class HeartbeatProtocol(Protocol):
@@ -23,17 +24,16 @@ class HeartbeatProtocol(Protocol):
 
 class HeartbeatFactory(Factory):
 
-    def __init__(self, only_ip="127.0.0.1"):
-        self.only_ip = only_ip
+    def __init__(self):
         self.status = "starting up"
         self.protocol = HeartbeatProtocol
         self.clients = []
         LoopingCall(self._heartbeat).start(10, now=True)
 
     def buildProtocol(self, addr):
-        if self.status in ("starting up", "generating GUID") and self.only_ip != "127.0.0.1":
+        if self.status in ("starting up", "generating GUID") and ALLOWIP != "127.0.0.1":
             return
-        if addr.host != self.only_ip and self.only_ip != "0.0.0.0":
+        if addr.host != ALLOWIP and ALLOWIP != "0.0.0.0":
             return
         return Factory.buildProtocol(self, addr)
 

--- a/net/utils.py
+++ b/net/utils.py
@@ -1,5 +1,7 @@
 import time
+from collections import namedtuple
 
+IP_Port = namedtuple('IP_Port', ['ip', 'port'])
 
 def looping_retry(func, *args):
     while True:

--- a/net/wireprotocol.py
+++ b/net/wireprotocol.py
@@ -36,7 +36,6 @@ class OpenBazaarProtocol(ConnectionMultiplexer):
                 ip_address: a `tuple` of the (ip address, port) of ths node.
         """
         self.ip_address = ip_address
-        self.testnet = testnet
         self.ws = None
         self.blockchain = None
         self.processors = []

--- a/ob.cfg
+++ b/ob.cfg
@@ -11,6 +11,13 @@ LIBBITCOIN_SERVER = tcp://libbitcoin1.openbazaar.org:9091
 LIBBITCOIN_SERVER_TESTNET = tcp://libbitcoin2.openbazaar.org:9091
 
 RESOLVER = http://resolver.onename.com/
+#TESTNET =
+#LOGLEVEL =
+#PORT =
+#ALLOWIP =
+#RESTPORT =
+#WSPORT = 
+#HEARTBEATPORT = 
 
 [AUTHENTICATION]
 
@@ -19,8 +26,8 @@ RESOLVER = http://resolver.onename.com/
 #SSL_CERT = /path/to/certificate.crt
 #SSL_KEY = /path/to/privkey.key
 
-#USERNAME = username
-#PASSWORD = password
+USERNAME = username
+PASSWORD = password
 
 [SEEDS]
 

--- a/ob.cfg
+++ b/ob.cfg
@@ -12,7 +12,7 @@ LIBBITCOIN_SERVER_TESTNET = tcp://libbitcoin2.openbazaar.org:9091
 
 RESOLVER = http://resolver.onename.com/
 #TESTNET =
-#LOGLEVEL =
+#LOGLEVEL = 
 #PORT =
 #ALLOWIP =
 #RESTPORT =

--- a/openbazaard.py
+++ b/openbazaard.py
@@ -11,7 +11,8 @@ import urllib2
 from api.ws import WSFactory, AuthenticatedWebSocketProtocol, AuthenticatedWebSocketFactory
 from api.restapi import RestAPI
 from config import DATA_FOLDER, KSIZE, ALPHA, LIBBITCOIN_SERVER,\
-    LIBBITCOIN_SERVER_TESTNET, SSL_KEY, SSL_CERT, SEEDS, SSL
+    LIBBITCOIN_SERVER_TESTNET, SSL_KEY, SSL_CERT, SEEDS, SSL,\
+    TESTNET, LOGLEVEL, PORT, ALLOWIP, WSPORT, HEARTBEATPORT
 from daemon import Daemon
 from db.datastore import Database
 from dht.network import Server
@@ -36,14 +37,8 @@ from twisted.python import log, logfile
 from txws import WebSocketFactory
 
 
-def run(*args):
-    TESTNET = args[0]
-    LOGLEVEL = args[1]
-    PORT = args[2]
-    ALLOWIP = args[3]
-    RESTPORT = args[4]
-    WSPORT = args[5]
-    HEARTBEATPORT = args[6]
+def run():
+    start_time = time.time()
 
     def start_server(keys, first_startup=False):
         # logging
@@ -158,7 +153,7 @@ def run(*args):
 
         heartbeat_server.set_status("online")
 
-        logger.info("Startup took %s seconds" % str(round(time.time() - args[7], 2)))
+        logger.info("Startup took %s seconds" % str(round(time.time() - start_time, 2)))
 
     # database
     db = Database(TESTNET)
@@ -215,15 +210,6 @@ commands:
             )
             parser.add_argument('-d', '--daemon', action='store_true',
                                 help="run the server in the background as a daemon")
-            parser.add_argument('-t', '--testnet', action='store_true', help="use the test network")
-            parser.add_argument('-l', '--loglevel', default="info",
-                                help="set the logging level [debug, info, warning, error, critical]")
-            parser.add_argument('-p', '--port', help="set the network port")
-            parser.add_argument('-a', '--allowip', default="127.0.0.1",
-                                help="only allow api connections from this ip")
-            parser.add_argument('-r', '--restapiport', help="set the rest api port", default=18469)
-            parser.add_argument('-w', '--websocketport', help="set the websocket api port", default=18466)
-            parser.add_argument('-b', '--heartbeatport', help="set the heartbeat port", default=18470)
             parser.add_argument('--pidfile', help="name of the pid file", default="openbazaard.pid")
             args = parser.parse_args(sys.argv[2:])
 
@@ -243,19 +229,11 @@ commands:
 
             unix = ("linux", "linux2", "darwin")
 
-            if args.port:
-                port = int(args.port)
-            else:
-                port = 18467 if not args.testnet else 28467
             if args.daemon and platform.system().lower() in unix:
                 self.daemon.pidfile = "/tmp/" + args.pidfile
-                self.daemon.start(args.testnet, args.loglevel, port, args.allowip,
-                                  int(args.restapiport), int(args.websocketport),
-                                  int(args.heartbeatport), time.time())
+                self.daemon.start()
             else:
-                run(args.testnet, args.loglevel, port, args.allowip,
-                    int(args.restapiport), int(args.websocketport),
-                    int(args.heartbeatport), time.time())
+                run()
 
         def stop(self):
             # pylint: disable=W0612

--- a/openbazaard.py
+++ b/openbazaard.py
@@ -8,50 +8,50 @@ import stun
 import sys
 import time
 import urllib2
+from obelisk.client import LibbitcoinClient
+from protos.objects import FULL_CONE, RESTRICTED, SYMMETRIC
+from twisted.internet import reactor, task
+from twisted.python import log, logfile
+from txws import WebSocketFactory
+from os.path import join
+
 from api.ws import WSFactory, AuthenticatedWebSocketProtocol, AuthenticatedWebSocketFactory
 from api.restapi import RestAPI
 from config import DATA_FOLDER, KSIZE, ALPHA, LIBBITCOIN_SERVER,\
     LIBBITCOIN_SERVER_TESTNET, SSL_KEY, SSL_CERT, SEEDS, SSL,\
-    TESTNET, LOGLEVEL, PORT, ALLOWIP, WSPORT, HEARTBEATPORT
+    TESTNET, LOGLEVEL, PORT, ALLOWIP, WSPORT, HEARTBEATPORT,\
+    RESTPORT
 from daemon import Daemon
 from db.datastore import Database
-from dht.network import Server
+from dht.network import Server as KServer
+from market.network import Server as MServer
 from dht.node import Node
 from dht.storage import PersistentStorage, ForgetfulStorage
 from keys.credentials import get_credentials
 from keys.keychain import KeyChain
 from log import Logger, FileLogObserver
-from market import network
 from market.listeners import MessageListenerImpl, BroadcastListenerImpl, NotificationListenerImpl
 from market.contracts import check_unfunded_for_payment
 from market.profile import Profile
 from net.heartbeat import HeartbeatFactory
 from net.sslcontext import ChainedOpenSSLContextFactory
 from net.upnp import PortMapper
-from net.utils import looping_retry
+from net.utils import looping_retry, IP_Port
 from net.wireprotocol import OpenBazaarProtocol
-from obelisk.client import LibbitcoinClient
-from protos.objects import FULL_CONE, RESTRICTED, SYMMETRIC
-from twisted.internet import reactor, task
-from twisted.python import log, logfile
-from txws import WebSocketFactory
 
+LOG_FILE = 'debug.log'
+LOGGER_INITIALISED = False
 
 def run():
-    start_time = time.time()
+    logger = _get_logger()
+ 
     _initialise_database()
+    logger.info('initialised database: %s' % Database.get_database_path())
+    
+    _initialise_heartbeat_server()
+    logger.info('initialised heartbeat server')
 
-    # heartbeat server
-    interface = "0.0.0.0" if ALLOWIP not in ("127.0.0.1", "0.0.0.0") else ALLOWIP
-    heartbeat_server = HeartbeatFactory(only_ip=ALLOWIP)
-    if SSL:
-        reactor.listenSSL(HEARTBEATPORT, WebSocketFactory(heartbeat_server),
-                          ChainedOpenSSLContextFactory(SSL_KEY, SSL_CERT), interface=interface)
-    else:
-        reactor.listenTCP(HEARTBEATPORT, WebSocketFactory(heartbeat_server), interface=interface)
-
-    # key generation
-    KeyChain(db, _start_server, heartbeat_server)
+    KeyChain(_start_server)     # uses threads so we need a callback function
 
     reactor.run()
 
@@ -60,120 +60,224 @@ def _initialise_database():
     Database()
 
 
+def _initialise_heartbeat_server():
+    heartbeat_server = HeartbeatFactory()
+    interface = _get_interface()
+    ws_factory = WebSocketFactory(heartbeat_server)
+
+    _connect_reactor(ws_factory)
+
+
 def _start_server(keys, first_startup=False):
-    # logging
-    logFile = logfile.LogFile.fromFullPath(DATA_FOLDER + "debug.log", rotateLength=15000000, maxRotatedFiles=1)
-    log.addObserver(FileLogObserver(logFile, level=LOGLEVEL).emit)
-    log.addObserver(FileLogObserver(level=LOGLEVEL).emit)
-    logger = Logger(system="OpenBazaard")
+    start_time = time.time()
+    logger = _get_logger()
 
-    # NAT traversal
-    p = PortMapper()
-    p.add_port_mapping(PORT, PORT, "UDP")
-    logger.info("Finding NAT Type...")
+    ip_address, nat_type = _initialise_nat_traversal()
 
-    response = looping_retry(stun.get_ip_info, "0.0.0.0", PORT)
+    protocol =  OpenBazaarProtocol(ip_address, nat_type)
 
-    logger.info("%s on %s:%s" % (response[0], response[1], response[2]))
-    ip_address = response[1]
-    port = response[2]
+    # kademlia
+    storage = _get_storage()
+    relay_node = _initialise_relay(nat_type)
+    protocol.relay_node = relay_node
 
-    if response[0] == "Full Cone":
-        nat_type = FULL_CONE
-    elif response[0] == "Restric NAT":
-        nat_type = RESTRICTED
-    else:
-        nat_type = SYMMETRIC
+    cache = join(DATA_FOLDER + 'cache.pickle')
 
     def on_bootstrap_complete(resp):
         logger.info("bootstrap complete")
         mserver.get_messages(mlistener)
-        task.LoopingCall(check_unfunded_for_payment, db, libbitcoin_client, nlistener, TESTNET).start(600)
+        task.LoopingCall(check_unfunded_for_payment,
+                         libbitcoin_client, nlistener).start(600)
 
-    protocol = OpenBazaarProtocol((ip_address, port), nat_type)
+    kserver = _initialise_kserver(keys, cache, ip_address, nat_type, relay_node,
+                                  on_bootstrap_complete, storage)
+    _connect_multiplexer_and_register_processor(protocol, kserver)
+    mserver = MServer(kserver, keys.signing_key)
+    _connect_multiplexer_and_register_processor(protocol, mserver)
+    
+    looping_retry(reactor.listenUDP, PORT, protocol)
 
-    # kademlia
-    storage = ForgetfulStorage() if TESTNET else PersistentStorage(db.get_database_path())
+    _initialise_rest_and_ws_api(mserver, kserver, protocol)
+    ws_api = WSFactory(mserver, kserver)
+    libbitcoin_client = _initialise_libbitcoin_client()
+    protocol.set_servers(ws_api, libbitcoin_client)
+    
+    listeners = _initialise_listeners(ws_api)
+    blistener, mlistener, nlistener = listeners # needed for closure
+    for listener in listeners:
+        mserver.protocol.add_listener(listener)
+
+    if first_startup:
+        _bring_heartbeat_server_online(first_startup)
+    
+    logger.info("Startup took %s seconds" % str(round(time.time() - start_time, 2)))
+
+
+def _get_interface():
+    interface = "0.0.0.0" if ALLOWIP not in ("127.0.0.1", "0.0.0.0") else ALLOWIP    
+    return interface
+
+
+def _connect_reactor(factory):
+    interface = _get_interface()
+    if SSL:
+        reactor.listenSSL(RESTPORT, factory,
+                          ChainedOpenSSLContextFactory(SSL_KEY, SSL_CERT),
+                          interface=interface)
+    else:
+        reactor.listenTCP(RESTPORT, factory, interface=interface)
+
+
+def _get_logger():
+    if not LOGGER_INITIALISED:
+        _initialise_logger()
+
+    return Logger(system="OpenBazaard")
+
+
+def _initialise_nat_traversal():
+    logger = _get_logger()
+    p = PortMapper()
+    p.add_port_mapping(PORT, PORT, "UDP")
+
+    logger.info("Finding NAT Type...")
+    response = looping_retry(stun.get_ip_info, "0.0.0.0", PORT)
+    logger.info("%s on %s:%s" % (response[0], response[1], response[2]))
+
+    nat_response = response[0]
+    ip = response[1]
+    port = response[2]
+    
+    if nat_response == "Full Cone":
+        nat_type = FULL_CONE
+    elif nat_response == "Restric NAT":
+        nat_type = RESTRICTED
+    else:
+        nat_type = SYMMETRIC
+
+    return ((ip, port), nat_type)
+
+
+def _get_storage():
+    """Get DHT storage object."""
+    if TESTNET:
+        return ForgetfulStorage()
+
+    db_path = Database.get_database_path()
+    return PersistentStorage(db_path)
+
+
+def _initialise_relay(nat_type):
     relay_node = None
     if nat_type != FULL_CONE:
         for seed in SEEDS:
             try:
-                relay_node = (socket.gethostbyname(seed[0].split(":")[0]),
-                              28469 if TESTNET else 18469)
+                relay_node = (socket.gethostbyname(seed[0].split(":")[0]), PORT)
                 break
             except socket.gaierror:
                 pass
 
+    return relay_node
+
+
+def _initialise_kserver(keys, cache, ip_address, nat_type, relay_node,
+                                  callback, storage):
+    """
+    Args:
+      ip_address: (ip, port)
+    """
+    ip = ip_address[0]
+    port = ip_address[1]
     try:
-        kserver = Server.loadState(DATA_FOLDER + 'cache.pickle', ip_address, port, protocol, db,
-                                   nat_type, relay_node, on_bootstrap_complete, storage)
+        kserver = KServer.loadState(cache, ip, port, nat_type,
+                                   relay_node, on_bootstrap_complete, storage)
     except Exception:
-        node = Node(keys.guid, ip_address, port, keys.verify_key.encode(),
-                    relay_node, nat_type, Profile(db).get().vendor)
-        protocol.relay_node = node.relay_node
-        kserver = Server(node, db, keys.signing_key, KSIZE, ALPHA, storage=storage)
-        kserver.protocol.connect_multiplexer(protocol)
+        node = Node(keys.guid, ip, port, keys.verify_key.encode(),
+                    relay_node, nat_type, Profile().get().vendor)
+        kserver = KServer(node, keys.signing_key, KSIZE, ALPHA, storage=storage)
         kserver.bootstrap(kserver.querySeed(SEEDS)).addCallback(on_bootstrap_complete)
-    kserver.saveStateRegularly(DATA_FOLDER + 'cache.pickle', 10)
-    protocol.register_processor(kserver.protocol)
 
-    # market
-    mserver = network.Server(kserver, keys.signing_key, db)
-    mserver.protocol.connect_multiplexer(protocol)
-    protocol.register_processor(mserver.protocol)
 
-    looping_retry(reactor.listenUDP, port, protocol)
+    kserver.saveStateRegularly(cache, 10)
 
-    interface = "0.0.0.0" if ALLOWIP not in ("127.0.0.1", "0.0.0.0") else ALLOWIP
 
-    # websockets api
-    authenticated_sessions = []
-    ws_api = WSFactory(mserver, kserver, only_ip=ALLOWIP)
-    ws_factory = AuthenticatedWebSocketFactory(ws_api)
-    ws_factory.authenticated_sessions = authenticated_sessions
-    ws_factory.protocol = AuthenticatedWebSocketProtocol
-    if SSL:
-        reactor.listenSSL(WSPORT, ws_factory,
-                          ChainedOpenSSLContextFactory(SSL_KEY, SSL_CERT), interface=interface)
-    else:
-        reactor.listenTCP(WSPORT, ws_factory, interface=interface)
+def _connect_multiplexer_and_register_processor(protocol, server):
+    server.protocol.connect_multiplexer(protocol)
+    protocol.register_processor(server.protocol)
 
-    # rest api
-    rest_api = RestAPI(mserver, kserver, protocol, username, password,
-                       authenticated_sessions, only_ip=ALLOWIP)
-    if SSL:
-        reactor.listenSSL(RESTPORT, rest_api,
-                          ChainedOpenSSLContextFactory(SSL_KEY, SSL_CERT), interface=interface)
-    else:
-        reactor.listenTCP(RESTPORT, rest_api, interface=interface)
 
-    # blockchain
+def _initialise_rest_and_ws_api(mserver, kserver, protocol):
+    authenticated_sessions = _initialise_ws(mserver, kserver)
+
+    rest_api = RestAPI(mserver, kserver, protocol, authenticated_sessions)
+
+    interface = _get_interface()
+    _connect_reactor(rest_api)
+
+
+def _initialise_libbitcoin_client():
+    logger = Logger(service="LibbitcoinClient")
+
     if TESTNET:
-        libbitcoin_client = LibbitcoinClient(LIBBITCOIN_SERVER_TESTNET, log=Logger(service="LibbitcoinClient"))
+        lbc_server = LIBBITCOIN_SERVER_TESTNET
     else:
-        libbitcoin_client = LibbitcoinClient(LIBBITCOIN_SERVER, log=Logger(service="LibbitcoinClient"))
+        lbc_server = LIBBITCOIN_SERVER
 
-    # listeners
-    nlistener = NotificationListenerImpl(ws_api, db)
-    mserver.protocol.add_listener(nlistener)
-    mlistener = MessageListenerImpl(ws_api, db)
-    mserver.protocol.add_listener(mlistener)
-    blistener = BroadcastListenerImpl(ws_api, db)
-    mserver.protocol.add_listener(blistener)
+    return LibbitcoinClient(lbc_server, log=logger)
 
-    protocol.set_servers(ws_api, libbitcoin_client)
 
-    if first_startup:
-        heartbeat_server.push(json.dumps({
-            "status": "GUID generation complete",
-            "username": username,
-            "password": password
-        }))
+def _initialise_listeners(ws_api):
+    nlistener = NotificationListenerImpl(ws_api)
+    mlistener = MessageListenerImpl(ws_api)
+    blistener = BroadcastListenerImpl(ws_api)
+
+    return (blistener, mlistener, nlisterner)
+
+
+def _bring_heartbeat_server_online():
+    heartbeat_server = HeartbeatServer()
+    username, password = get_credentials()
+    heartbeat_server.push(json.dumps({
+        "status": "GUID generation complete",
+        "username": username,
+        "password": password
+    }))
 
     heartbeat_server.set_status("online")
 
-    logger.info("Startup took %s seconds" % str(round(time.time() - start_time, 2)))
 
+def _initialise_logger():
+    global LOGGER_INITIALISED
+
+    log_file = join(DATA_FOLDER, LOG_FILE)
+    _add_log_observer_to_file(log_file)
+    _add_log_observer_to_stdout()
+
+    logger = Logger(system="OpenBazaard")
+    logger.info('initialised logger: %s' % log_file)
+    
+    LOGGER_INITIALISED = True
+
+
+def _initialise_ws(mserver, kserver):
+    interface = _get_interface()
+    authenticated_sessions = []
+    ws_api = WSFactory(mserver, kserver)
+    ws_factory = AuthenticatedWebSocketFactory(ws_api)
+    ws_factory.authenticated_sessions = authenticated_sessions
+    ws_factory.protocol = AuthenticatedWebSocketProtocol
+
+    _connect_reactor(ws_factory)
+
+    return authenticated_sessions
+
+
+def _add_log_observer_to_file(log_file):
+    log.addObserver(FileLogObserver(log_file, level=LOGLEVEL).emit)
+
+
+def _add_log_observer_to_stdout():
+    log.addObserver(FileLogObserver(level=LOGLEVEL).emit)
 
 
 if __name__ == "__main__":

--- a/openbazaard.py
+++ b/openbazaard.py
@@ -39,127 +39,7 @@ from txws import WebSocketFactory
 
 def run():
     start_time = time.time()
-
-    def start_server(keys, first_startup=False):
-        # logging
-        logFile = logfile.LogFile.fromFullPath(DATA_FOLDER + "debug.log", rotateLength=15000000, maxRotatedFiles=1)
-        log.addObserver(FileLogObserver(logFile, level=LOGLEVEL).emit)
-        log.addObserver(FileLogObserver(level=LOGLEVEL).emit)
-        logger = Logger(system="OpenBazaard")
-
-        # NAT traversal
-        p = PortMapper()
-        p.add_port_mapping(PORT, PORT, "UDP")
-        logger.info("Finding NAT Type...")
-
-        response = looping_retry(stun.get_ip_info, "0.0.0.0", PORT)
-
-        logger.info("%s on %s:%s" % (response[0], response[1], response[2]))
-        ip_address = response[1]
-        port = response[2]
-
-        if response[0] == "Full Cone":
-            nat_type = FULL_CONE
-        elif response[0] == "Restric NAT":
-            nat_type = RESTRICTED
-        else:
-            nat_type = SYMMETRIC
-
-        def on_bootstrap_complete(resp):
-            logger.info("bootstrap complete")
-            mserver.get_messages(mlistener)
-            task.LoopingCall(check_unfunded_for_payment, db, libbitcoin_client, nlistener, TESTNET).start(600)
-
-        protocol = OpenBazaarProtocol(db, (ip_address, port), nat_type, testnet=TESTNET,
-                                      relaying=True if nat_type == FULL_CONE else False)
-
-        # kademlia
-        storage = ForgetfulStorage() if TESTNET else PersistentStorage(db.get_database_path())
-        relay_node = None
-        if nat_type != FULL_CONE:
-            for seed in SEEDS:
-                try:
-                    relay_node = (socket.gethostbyname(seed[0].split(":")[0]),
-                                  28469 if TESTNET else 18469)
-                    break
-                except socket.gaierror:
-                    pass
-
-        try:
-            kserver = Server.loadState(DATA_FOLDER + 'cache.pickle', ip_address, port, protocol, db,
-                                       nat_type, relay_node, on_bootstrap_complete, storage)
-        except Exception:
-            node = Node(keys.guid, ip_address, port, keys.verify_key.encode(),
-                        relay_node, nat_type, Profile(db).get().vendor)
-            protocol.relay_node = node.relay_node
-            kserver = Server(node, db, keys.signing_key, KSIZE, ALPHA, storage=storage)
-            kserver.protocol.connect_multiplexer(protocol)
-            kserver.bootstrap(kserver.querySeed(SEEDS)).addCallback(on_bootstrap_complete)
-        kserver.saveStateRegularly(DATA_FOLDER + 'cache.pickle', 10)
-        protocol.register_processor(kserver.protocol)
-
-        # market
-        mserver = network.Server(kserver, keys.signing_key, db)
-        mserver.protocol.connect_multiplexer(protocol)
-        protocol.register_processor(mserver.protocol)
-
-        looping_retry(reactor.listenUDP, port, protocol)
-
-        interface = "0.0.0.0" if ALLOWIP not in ("127.0.0.1", "0.0.0.0") else ALLOWIP
-
-        # websockets api
-        authenticated_sessions = []
-        ws_api = WSFactory(mserver, kserver, only_ip=ALLOWIP)
-        ws_factory = AuthenticatedWebSocketFactory(ws_api)
-        ws_factory.authenticated_sessions = authenticated_sessions
-        ws_factory.protocol = AuthenticatedWebSocketProtocol
-        if SSL:
-            reactor.listenSSL(WSPORT, ws_factory,
-                              ChainedOpenSSLContextFactory(SSL_KEY, SSL_CERT), interface=interface)
-        else:
-            reactor.listenTCP(WSPORT, ws_factory, interface=interface)
-
-        # rest api
-        rest_api = RestAPI(mserver, kserver, protocol, username, password,
-                           authenticated_sessions, only_ip=ALLOWIP)
-        if SSL:
-            reactor.listenSSL(RESTPORT, rest_api,
-                              ChainedOpenSSLContextFactory(SSL_KEY, SSL_CERT), interface=interface)
-        else:
-            reactor.listenTCP(RESTPORT, rest_api, interface=interface)
-
-        # blockchain
-        if TESTNET:
-            libbitcoin_client = LibbitcoinClient(LIBBITCOIN_SERVER_TESTNET, log=Logger(service="LibbitcoinClient"))
-        else:
-            libbitcoin_client = LibbitcoinClient(LIBBITCOIN_SERVER, log=Logger(service="LibbitcoinClient"))
-
-        # listeners
-        nlistener = NotificationListenerImpl(ws_api, db)
-        mserver.protocol.add_listener(nlistener)
-        mlistener = MessageListenerImpl(ws_api, db)
-        mserver.protocol.add_listener(mlistener)
-        blistener = BroadcastListenerImpl(ws_api, db)
-        mserver.protocol.add_listener(blistener)
-
-        protocol.set_servers(ws_api, libbitcoin_client)
-
-        if first_startup:
-            heartbeat_server.push(json.dumps({
-                "status": "GUID generation complete",
-                "username": username,
-                "password": password
-            }))
-
-        heartbeat_server.set_status("online")
-
-        logger.info("Startup took %s seconds" % str(round(time.time() - start_time, 2)))
-
-    # database
-    db = Database()
-
-    # client authentication
-    username, password = get_credentials()
+    _initialise_database()
 
     # heartbeat server
     interface = "0.0.0.0" if ALLOWIP not in ("127.0.0.1", "0.0.0.0") else ALLOWIP
@@ -171,9 +51,130 @@ def run():
         reactor.listenTCP(HEARTBEATPORT, WebSocketFactory(heartbeat_server), interface=interface)
 
     # key generation
-    KeyChain(db, start_server, heartbeat_server)
+    KeyChain(db, _start_server, heartbeat_server)
 
     reactor.run()
+
+
+def _initialise_database():
+    Database()
+
+
+def _start_server(keys, first_startup=False):
+    # logging
+    logFile = logfile.LogFile.fromFullPath(DATA_FOLDER + "debug.log", rotateLength=15000000, maxRotatedFiles=1)
+    log.addObserver(FileLogObserver(logFile, level=LOGLEVEL).emit)
+    log.addObserver(FileLogObserver(level=LOGLEVEL).emit)
+    logger = Logger(system="OpenBazaard")
+
+    # NAT traversal
+    p = PortMapper()
+    p.add_port_mapping(PORT, PORT, "UDP")
+    logger.info("Finding NAT Type...")
+
+    response = looping_retry(stun.get_ip_info, "0.0.0.0", PORT)
+
+    logger.info("%s on %s:%s" % (response[0], response[1], response[2]))
+    ip_address = response[1]
+    port = response[2]
+
+    if response[0] == "Full Cone":
+        nat_type = FULL_CONE
+    elif response[0] == "Restric NAT":
+        nat_type = RESTRICTED
+    else:
+        nat_type = SYMMETRIC
+
+    def on_bootstrap_complete(resp):
+        logger.info("bootstrap complete")
+        mserver.get_messages(mlistener)
+        task.LoopingCall(check_unfunded_for_payment, db, libbitcoin_client, nlistener, TESTNET).start(600)
+
+    protocol = OpenBazaarProtocol((ip_address, port), nat_type)
+
+    # kademlia
+    storage = ForgetfulStorage() if TESTNET else PersistentStorage(db.get_database_path())
+    relay_node = None
+    if nat_type != FULL_CONE:
+        for seed in SEEDS:
+            try:
+                relay_node = (socket.gethostbyname(seed[0].split(":")[0]),
+                              28469 if TESTNET else 18469)
+                break
+            except socket.gaierror:
+                pass
+
+    try:
+        kserver = Server.loadState(DATA_FOLDER + 'cache.pickle', ip_address, port, protocol, db,
+                                   nat_type, relay_node, on_bootstrap_complete, storage)
+    except Exception:
+        node = Node(keys.guid, ip_address, port, keys.verify_key.encode(),
+                    relay_node, nat_type, Profile(db).get().vendor)
+        protocol.relay_node = node.relay_node
+        kserver = Server(node, db, keys.signing_key, KSIZE, ALPHA, storage=storage)
+        kserver.protocol.connect_multiplexer(protocol)
+        kserver.bootstrap(kserver.querySeed(SEEDS)).addCallback(on_bootstrap_complete)
+    kserver.saveStateRegularly(DATA_FOLDER + 'cache.pickle', 10)
+    protocol.register_processor(kserver.protocol)
+
+    # market
+    mserver = network.Server(kserver, keys.signing_key, db)
+    mserver.protocol.connect_multiplexer(protocol)
+    protocol.register_processor(mserver.protocol)
+
+    looping_retry(reactor.listenUDP, port, protocol)
+
+    interface = "0.0.0.0" if ALLOWIP not in ("127.0.0.1", "0.0.0.0") else ALLOWIP
+
+    # websockets api
+    authenticated_sessions = []
+    ws_api = WSFactory(mserver, kserver, only_ip=ALLOWIP)
+    ws_factory = AuthenticatedWebSocketFactory(ws_api)
+    ws_factory.authenticated_sessions = authenticated_sessions
+    ws_factory.protocol = AuthenticatedWebSocketProtocol
+    if SSL:
+        reactor.listenSSL(WSPORT, ws_factory,
+                          ChainedOpenSSLContextFactory(SSL_KEY, SSL_CERT), interface=interface)
+    else:
+        reactor.listenTCP(WSPORT, ws_factory, interface=interface)
+
+    # rest api
+    rest_api = RestAPI(mserver, kserver, protocol, username, password,
+                       authenticated_sessions, only_ip=ALLOWIP)
+    if SSL:
+        reactor.listenSSL(RESTPORT, rest_api,
+                          ChainedOpenSSLContextFactory(SSL_KEY, SSL_CERT), interface=interface)
+    else:
+        reactor.listenTCP(RESTPORT, rest_api, interface=interface)
+
+    # blockchain
+    if TESTNET:
+        libbitcoin_client = LibbitcoinClient(LIBBITCOIN_SERVER_TESTNET, log=Logger(service="LibbitcoinClient"))
+    else:
+        libbitcoin_client = LibbitcoinClient(LIBBITCOIN_SERVER, log=Logger(service="LibbitcoinClient"))
+
+    # listeners
+    nlistener = NotificationListenerImpl(ws_api, db)
+    mserver.protocol.add_listener(nlistener)
+    mlistener = MessageListenerImpl(ws_api, db)
+    mserver.protocol.add_listener(mlistener)
+    blistener = BroadcastListenerImpl(ws_api, db)
+    mserver.protocol.add_listener(blistener)
+
+    protocol.set_servers(ws_api, libbitcoin_client)
+
+    if first_startup:
+        heartbeat_server.push(json.dumps({
+            "status": "GUID generation complete",
+            "username": username,
+            "password": password
+        }))
+
+    heartbeat_server.set_status("online")
+
+    logger.info("Startup took %s seconds" % str(round(time.time() - start_time, 2)))
+
+
 
 if __name__ == "__main__":
     # pylint: disable=anomalous-backslash-in-string

--- a/openbazaard.py
+++ b/openbazaard.py
@@ -156,10 +156,10 @@ def run():
         logger.info("Startup took %s seconds" % str(round(time.time() - start_time, 2)))
 
     # database
-    db = Database(TESTNET)
+    db = Database()
 
     # client authentication
-    username, password = get_credentials(db)
+    username, password = get_credentials()
 
     # heartbeat server
     interface = "0.0.0.0" if ALLOWIP not in ("127.0.0.1", "0.0.0.0") else ALLOWIP


### PR DESCRIPTION
This patch removes command line options. The reasoning being that if we accept that command line options currently cannot override config file options then they are inherently broken. As a small step towards fixing this lets remove command line options for now, put all the config into the config file. This gives us allot of the benefits of #215 with out the sweeping changes. With this patch in place we no longer need to pass TESTNET around or pass the db around. If this patch is merged it will allow a number functions to be simplified

Once a method for parsing the command line options is settled on adding it requires no changes then to the rest of the project only to config.py and openbazaard.py (as the main benefits have already been realised, and hopefully utilised). 