### PR TITLE
Upgrade protobuf to 3.0.0b2 to fix unicode bugs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-protobuf==2.6.1
+protobuf==3.0.0b2
 Twisted==14.0.2
 txrudp==0.5.1
 pystun==0.1.0


### PR DESCRIPTION
Google protobuf 2.6.1 has a serious bug: string field only accept ascii 7-bit string not utf-8 string.
So user can not create/edit an item with unicode title or category.

Upgrade protobuf to 3.0.0b2 can fix this bug.