### PR TITLE
Upgrade protobuf to 3.0.0b2 to fix unicode bugs

### DIFF
--- a/api/restapi.py
+++ b/api/restapi.py
@@ -580,6 +580,8 @@ class OpenBazaarAPI(APIResource):
                 if "keywords" in c.contract["vendor_offer"]["listing"]["item"]:
                     for keyword in c.contract["vendor_offer"]["listing"]["item"]["keywords"]:
                         if keyword != "":
+                            if isinstance(keyword, unicode):
+                                keyword = keyword.encode('utf8')
                             self.kserver.delete(keyword.lower(), unhexlify(c.get_contract_id()),
                                                 self.keychain.signing_key.sign(
                                                     unhexlify(c.get_contract_id()))[:64])

--- a/market/contracts.py
+++ b/market/contracts.py
@@ -923,6 +923,8 @@ class Contract(object):
         with open(file_path, 'w') as outfile:
             outfile.write(json.dumps(self.contract, indent=4))
 
+        if isinstance(self.previous_title, unicode):
+            self.previous_title = self.previous_title.encode('utf8')
         if self.previous_title and self.previous_title != self.contract["vendor_offer"]["listing"]["item"]["title"]:
             old_name = str(self.previous_title[:100])
             old_name = re.sub(r"[^\w\s]", '', file_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-protobuf==2.6.1
+protobuf==3.0.0b2
 Twisted==14.0.2
 txrudp==0.5.1
 pystun==0.1.0


### PR DESCRIPTION
Google protobuf 2.6.1 has a serious bug: string field only accept ascii 7-bit string not utf-8 string.
So user can not create/edit an item with unicode title or category.

Upgrade protobuf to 3.0.0b2 can fix this bug.
