### PR TITLE
Allow multiple --allowip parameters.

### DIFF
--- a/api/restapi.py
+++ b/api/restapi.py
@@ -1348,13 +1348,13 @@ class OpenBazaarAPI(APIResource):
 class RestAPI(Site):
 
     def __init__(self, mserver, kserver, openbazaar_protocol, username, password,
-                 authenticated_sessions, only_ip="127.0.0.1", timeout=60 * 60 * 1):
+                 authenticated_sessions, only_ip=["127.0.0.1"], timeout=60 * 60 * 1):
         self.only_ip = only_ip
         api_resource = OpenBazaarAPI(mserver, kserver, openbazaar_protocol,
                                      username, password, authenticated_sessions)
         Site.__init__(self, api_resource, timeout=timeout)
 
     def buildProtocol(self, addr):
-        if addr.host != self.only_ip and self.only_ip != "0.0.0.0":
+        if addr.host not in self.only_ip and "0.0.0.0" not in self.only_ip:
             return
         return Site.buildProtocol(self, addr)

--- a/api/restapi.py
+++ b/api/restapi.py
@@ -1348,7 +1348,9 @@ class OpenBazaarAPI(APIResource):
 class RestAPI(Site):
 
     def __init__(self, mserver, kserver, openbazaar_protocol, username, password,
-                 authenticated_sessions, only_ip=["127.0.0.1"], timeout=60 * 60 * 1):
+                 authenticated_sessions, only_ip=None, timeout=60 * 60 * 1):
+        if only_ip == None:
+            only_ip = ["127.0.0.1"]
         self.only_ip = only_ip
         api_resource = OpenBazaarAPI(mserver, kserver, openbazaar_protocol,
                                      username, password, authenticated_sessions)

--- a/api/ws.py
+++ b/api/ws.py
@@ -302,7 +302,7 @@ class WSProtocol(Protocol):
 
 class WSFactory(Factory):
 
-    def __init__(self, mserver, kserver, only_ip="127.0.0.1"):
+    def __init__(self, mserver, kserver, only_ip=["127.0.0.1"]):
         self.mserver = mserver
         self.kserver = kserver
         self.db = mserver.db
@@ -313,7 +313,7 @@ class WSFactory(Factory):
         self.clients = []
 
     def buildProtocol(self, addr):
-        if addr.host != self.only_ip and self.only_ip != "0.0.0.0":
+        if addr.host not in self.only_ip and "0.0.0.0" not in self.only_ip:
             return
         return Factory.buildProtocol(self, addr)
 

--- a/api/ws.py
+++ b/api/ws.py
@@ -302,7 +302,9 @@ class WSProtocol(Protocol):
 
 class WSFactory(Factory):
 
-    def __init__(self, mserver, kserver, only_ip=["127.0.0.1"]):
+    def __init__(self, mserver, kserver, only_ip=None):
+        if only_ip == None:
+            only_ip = ["127.0.0.1"]
         self.mserver = mserver
         self.kserver = kserver
         self.db = mserver.db

--- a/net/heartbeat.py
+++ b/net/heartbeat.py
@@ -23,7 +23,7 @@ class HeartbeatProtocol(Protocol):
 
 class HeartbeatFactory(Factory):
 
-    def __init__(self, only_ip="127.0.0.1"):
+    def __init__(self, only_ip=["127.0.0.1"]):
         self.only_ip = only_ip
         self.status = "starting up"
         self.protocol = HeartbeatProtocol
@@ -32,9 +32,9 @@ class HeartbeatFactory(Factory):
         LoopingCall(self._heartbeat).start(10, now=True)
 
     def buildProtocol(self, addr):
-        if self.status in ("starting up", "generating GUID") and self.only_ip != "127.0.0.1":
+        if self.status in ("starting up", "generating GUID") and "127.0.0.1" not in self.only_ip:
             return
-        if addr.host != self.only_ip and self.only_ip != "0.0.0.0":
+        if addr.host not in self.only_ip and "0.0.0.0" not in self.only_ip:
             return
         return Factory.buildProtocol(self, addr)
 

--- a/net/heartbeat.py
+++ b/net/heartbeat.py
@@ -23,7 +23,9 @@ class HeartbeatProtocol(Protocol):
 
 class HeartbeatFactory(Factory):
 
-    def __init__(self, only_ip=["127.0.0.1"]):
+    def __init__(self, only_ip=None):
+        if only_ip == None:
+            only_ip = ["127.0.0.1"]
         self.only_ip = only_ip
         self.status = "starting up"
         self.protocol = HeartbeatProtocol
@@ -32,7 +34,7 @@ class HeartbeatFactory(Factory):
         LoopingCall(self._heartbeat).start(10, now=True)
 
     def buildProtocol(self, addr):
-        if self.status in ("starting up", "generating GUID") and "127.0.0.1" not in self.only_ip:
+        if self.status in ("starting up", "generating GUID") and self.only_ip != ["127.0.0.1"]:
             return
         if addr.host not in self.only_ip and "0.0.0.0" not in self.only_ip:
             return

--- a/openbazaard.py
+++ b/openbazaard.py
@@ -109,9 +109,7 @@ def run(*args):
 
         looping_retry(reactor.listenUDP, port, protocol)
 
-        #interface = "0.0.0.0" if ALLOWIP not in ("127.0.0.1", "0.0.0.0") else ALLOWIP
-        if not ALLOWIP:
-            ALLOWIP = "0.0.0.0"
+        interface = "0.0.0.0" if ALLOWIP != ["127.0.0.1"] else "127.0.0.1"
 
         # websockets api
         authenticated_sessions = []
@@ -178,9 +176,7 @@ def run(*args):
     username, password = get_credentials(db)
 
     # heartbeat server
-    #interface = "0.0.0.0" if ALLOWIP not in ("127.0.0.1", "0.0.0.0") else ALLOWIP
-    if not ALLOWIP:
-        ALLOWIP = ["0.0.0.0"]
+    interface = "0.0.0.0" if ALLOWIP != ["127.0.0.1"] else "127.0.0.1"
         
     heartbeat_server = HeartbeatFactory(only_ip=ALLOWIP)
     if SSL:
@@ -233,7 +229,7 @@ commands:
             parser.add_argument('-l', '--loglevel', default="info",
                                 help="set the logging level [debug, info, warning, error, critical]")
             parser.add_argument('-p', '--port', help="set the network port")
-            parser.add_argument('-a', '--allowip', default="127.0.0.1", action="append"
+            parser.add_argument('-a', '--allowip', default=["127.0.0.1"], action="append",
                                 help="only allow api connections from this ip")
             parser.add_argument('-r', '--restapiport', help="set the rest api port", default=18469)
             parser.add_argument('-w', '--websocketport', help="set the websocket api port", default=18466)

--- a/openbazaard.py
+++ b/openbazaard.py
@@ -177,7 +177,7 @@ def run(*args):
 
     # heartbeat server
     interface = "0.0.0.0" if ALLOWIP != ["127.0.0.1"] else "127.0.0.1"
-        
+
     heartbeat_server = HeartbeatFactory(only_ip=ALLOWIP)
     if SSL:
         reactor.listenSSL(HEARTBEATPORT, WebSocketFactory(heartbeat_server),

--- a/openbazaard.py
+++ b/openbazaard.py
@@ -109,7 +109,9 @@ def run(*args):
 
         looping_retry(reactor.listenUDP, port, protocol)
 
-        interface = "0.0.0.0" if ALLOWIP not in ("127.0.0.1", "0.0.0.0") else ALLOWIP
+        #interface = "0.0.0.0" if ALLOWIP not in ("127.0.0.1", "0.0.0.0") else ALLOWIP
+        if not ALLOWIP:
+            ALLOWIP = "0.0.0.0"
 
         # websockets api
         authenticated_sessions = []
@@ -176,7 +178,10 @@ def run(*args):
     username, password = get_credentials(db)
 
     # heartbeat server
-    interface = "0.0.0.0" if ALLOWIP not in ("127.0.0.1", "0.0.0.0") else ALLOWIP
+    #interface = "0.0.0.0" if ALLOWIP not in ("127.0.0.1", "0.0.0.0") else ALLOWIP
+    if not ALLOWIP:
+        ALLOWIP = ["0.0.0.0"]
+        
     heartbeat_server = HeartbeatFactory(only_ip=ALLOWIP)
     if SSL:
         reactor.listenSSL(HEARTBEATPORT, WebSocketFactory(heartbeat_server),
@@ -228,7 +233,7 @@ commands:
             parser.add_argument('-l', '--loglevel', default="info",
                                 help="set the logging level [debug, info, warning, error, critical]")
             parser.add_argument('-p', '--port', help="set the network port")
-            parser.add_argument('-a', '--allowip', default="127.0.0.1",
+            parser.add_argument('-a', '--allowip', default="127.0.0.1", action="append"
                                 help="only allow api connections from this ip")
             parser.add_argument('-r', '--restapiport', help="set the rest api port", default=18469)
             parser.add_argument('-w', '--websocketport', help="set the websocket api port", default=18466)


### PR DESCRIPTION
This changes the -a --allowip argument to a list (append) instead of a string so that multiple entries can be used.  All references to ALLOWIP and only_ip were changed to use a list instead of a string.

The changes were tested by ssh local port forwarding to different hosts.