### PR TITLE
BUGFIX: Ensure DATA_FOLDER ends in a path separator.

### DIFF
--- a/config.py
+++ b/config.py
@@ -161,7 +161,7 @@ if isfile(CONFIG_FILE):
 else:
     print 'Warning: configuration file not found: (%s), using default values' % CONFIG_FILE
 
-DATA_FOLDER = _platform_agnostic_data_path(cfg.get('CONSTANTS', 'DATA_FOLDER'))
+DATA_FOLDER = join(_platform_agnostic_data_path(cfg.get('CONSTANTS', 'DATA_FOLDER'), ''))
 KSIZE = int(cfg.get('CONSTANTS', 'KSIZE'))
 ALPHA = int(cfg.get('CONSTANTS', 'ALPHA'))
 TRANSACTION_FEE = int(cfg.get('CONSTANTS', 'TRANSACTION_FEE'))


### PR DESCRIPTION
If you don't include a path separator in your DATA_FOLDER definition, then instead of saving things in e.g. `/path/to/data/keys.pickle` it will save to `/path/to/datakeys.pickle`.

The proper fix is to use os.path.join everywhere we use file paths. But until then, this will make things better.