### PR TITLE
Changed BitcoinAverage endpoint

### DIFF
--- a/market/btcprice.py
+++ b/market/btcprice.py
@@ -86,7 +86,7 @@ class BtcPrice(Thread):
         return json.loads(result)
 
     def loadbitcoinaverage(self):
-        for currency, info in self.dictForUrl('https://api.bitcoinaverage.com/ticker/all').iteritems():
+        for currency, info in self.dictForUrl('https://api.bitcoinaverage.com/ticker/global/all').iteritems():
             if currency != "timestamp":
                 self.prices[currency] = info["last"]
 


### PR DESCRIPTION
A bug report was emailed into us, this endpoint change will prevent 0 values for local currency markets that don't have exchanges integrated on a certain cycle.