### PR TITLE
Sanitize html without returning malformed JSON

### DIFF
--- a/api/restapi.py
+++ b/api/restapi.py
@@ -28,7 +28,7 @@ from market.contracts import Contract, check_order_for_payment
 from market.btcprice import BtcPrice
 from net.upnp import PortMapper
 from api import ALLOWED_TAGS, ALLOWED_ATTRIBUTES, ALLOWED_STYLES
-from utils import sanitize_html
+from api.utils import sanitize_html
 
 DEFAULT_RECORDS_COUNT = 20
 DEFAULT_RECORDS_OFFSET = 0

--- a/api/restapi.py
+++ b/api/restapi.py
@@ -28,6 +28,7 @@ from market.contracts import Contract, check_order_for_payment
 from market.btcprice import BtcPrice
 from net.upnp import PortMapper
 from api import ALLOWED_TAGS, ALLOWED_ATTRIBUTES, ALLOWED_STYLES
+from utils import sanitize_html
 
 DEFAULT_RECORDS_COUNT = 20
 DEFAULT_RECORDS_OFFSET = 0
@@ -494,7 +495,7 @@ class OpenBazaarAPI(APIResource):
         def parse_contract(contract):
             if contract is not None:
                 request.setHeader('content-type', "application/json")
-                request.write(bleach.clean(json.dumps(contract, indent=4), tags=ALLOWED_TAGS).encode("utf-8"))
+                request.write(json.dumps(sanitize_html(contract), indent=4))
                 request.finish()
             else:
                 request.write(json.dumps({}))

--- a/api/utils.py
+++ b/api/utils.py
@@ -39,7 +39,7 @@ def smart_str(s, encoding='utf8'):
     return s.encode(encoding)
 
 def sanitize_html(value):
-    """ Recursively sanitize all strings within a data structure. """    
+    """ Recursively sanitize all strings within a data structure. """
     if isinstance(value, dict):
         value = {k:sanitize_html(v) for k, v in value.iteritems()}
     elif isinstance(value, list):

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,5 +1,7 @@
 import bleach
 
+from api import ALLOWED_TAGS, ALLOWED_ATTRIBUTES, ALLOWED_STYLES
+
 # pylint: disable=W1402
 def smart_unicode(s, encoding='utf8'):
     """ Convert str to unicode. If s is unicode, return itself.
@@ -43,5 +45,5 @@ def sanitize_html(value):
     elif isinstance(value, list):
         value = [sanitize_html(v) for v in value]
     elif isinstance(value, basestring):
-        value = bleach.clean(value)
+        value = bleach.clean(value, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES, styles=ALLOWED_STYLES)
     return value

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,3 +1,5 @@
+import bleach
+
 # pylint: disable=W1402
 def smart_unicode(s, encoding='utf8'):
     """ Convert str to unicode. If s is unicode, return itself.
@@ -33,3 +35,13 @@ def smart_str(s, encoding='utf8'):
     if isinstance(s, str):
         return s
     return s.encode(encoding)
+
+def sanitize_html(value):
+    """ Recursively sanitize all strings within a data structure. """    
+    if isinstance(value, dict):
+        value = {k:sanitize_html(v) for k, v in value.iteritems()}
+    elif isinstance(value, list):
+        value = [sanitize_html(v) for v in value]
+    elif isinstance(value, basestring):
+        value = bleach.clean(value)
+    return value


### PR DESCRIPTION
The main purpose of this PR is to show a proof-of-concept of an alternate way to sanitize html on the server to avoid the incessant (and still around) malformed JSON errors. The problem with the current way it's being done is that the full serialized JSON string is being cleaned via `bleach.clean()`. But, Bleach's role is to sanitize HTML. It makes no claims to output valid JSON. The proposed proper way to do it, is to sanitize the strings in your data structure first and then serialize (via `json.dumps()`) the data structure into JSON and return it.

Manually and explicitly running each string in every returned data structure through the sanitizer would be very cumbersome. This PR introduces a function (`sanitize_html') which will recursively iterate through a given data structure and sanitize any strings within it.

To test it out, it has been applied to the GET contracts endpoint, which had been returning malformed JSON if the steps outlined in a comment in https://github.com/OpenBazaar/OpenBazaar-Client/issues/1335 are followed. After applying the changes in the PR, the issue is no longer present (i.e. well-formed JSON is returned!!!).

If this solution is found to be acceptable, I could happily apply it to all areas returning sanitized html to the client. Please let me know.