### PR TITLE
Warning logging level set to higher priority than info

### DIFF
--- a/log.py
+++ b/log.py
@@ -6,12 +6,12 @@ import sys
 from twisted.python import log
 
 DEBUG = 5
-WARNING = 4
-INFO = 3
+INFO = 4
+WARNING = 3
 ERROR = 2
 CRITICAL = 1
 
-levels = {"debug": 5, "warning": 4, "info": 3, "error": 2, "critical": 1}
+levels = {"debug": 5, "info": 4, "warning": 3, "error": 2, "critical": 1}
 
 class FileLogObserver(log.FileLogObserver):
     def __init__(self, f=None, level="info", default=DEBUG):

--- a/openbazaard.py
+++ b/openbazaard.py
@@ -167,7 +167,7 @@ def run(*args):
         logger.info("startup took %s seconds" % str(round(time.time() - args[7], 2)))
 
         def shutdown():
-            logger.info("shutting down server")
+            print "OpenBazaar Server v0.1 shutting down..."
             for vendor in protocol.vendors.values():
                 db.vendors.save_vendor(vendor.id.encode("hex"), vendor.getProto().SerializeToString())
             PortMapper().clean_my_mappings(PORT)
@@ -239,7 +239,7 @@ commands:
             parser.add_argument('-d', '--daemon', action='store_true',
                                 help="run the server in the background as a daemon")
             parser.add_argument('-t', '--testnet', action='store_true', help="use the test network")
-            parser.add_argument('-l', '--loglevel', default="info",
+            parser.add_argument('-l', '--loglevel', default="warning",
                                 help="set the logging level [debug, info, warning, error, critical]")
             parser.add_argument('-p', '--port', help="set the network port")
             parser.add_argument('-a', '--allowip', default=["127.0.0.1"], action="append",


### PR DESCRIPTION
I noticed the "warning" logging level was set to lower priority than "info" when I was trying to debug something, so I switched those.

Also, just a suggestion: I think the default logging level should be set to "warning" because it's hard to notice any warnings/errors when a list of peer connections is constantly streaming through my terminal.
