### PR TITLE
Adding the ability to get sales by their status to the REST API (and to db.sales)

### DIFF
--- a/api/restapi.py
+++ b/api/restapi.py
@@ -1110,7 +1110,10 @@ class OpenBazaarAPI(APIResource):
     @GET('^/api/v1/get_sales')
     @authenticated
     def get_sales(self, request):
-        sales = self.db.sales.get_all()
+        if "status" in request.args:
+            sales = self.db.sales.get_by_status(request.args["status"][0])
+        else:
+            sales = self.db.sales.get_all()
         sales_list = []
         for sale in sales:
             sale_json = {

--- a/db/datastore.py
+++ b/db/datastore.py
@@ -1084,6 +1084,16 @@ thumbnail, buyer, contractType, unread, statusChanged FROM sales ''')
         conn.close()
         return ret
 
+    def get_by_status(self, status):
+        conn = Database.connect_database(self.PATH)
+        cursor = conn.cursor()
+        cursor.execute('''SELECT id, title, description, timestamp, btc, status,
+thumbnail, buyer, contractType, unread, statusChanged FROM sales WHERE
+status=?''', (status,))
+        ret = cursor.fetchall()
+        conn.close()
+        return ret
+
     def get_unfunded(self):
         conn = Database.connect_database(self.PATH)
         cursor = conn.cursor()


### PR DESCRIPTION
I want to be able to get a list of sales in a certain status. It seems like it would be most efficient to be able to offload this sort of processing to the DB, so that's what I did.

It should be backwards compatible with the old get_sales calls as well.
