### PR TITLE
Use http instead of https for bitcoincharts

### DIFF
--- a/market/btcprice.py
+++ b/market/btcprice.py
@@ -99,6 +99,6 @@ class BtcPrice(Thread):
             self.prices[currency] = info["last"]
 
     def loadbitcoincharts(self):
-        for currency, info in self.dictForUrl('https://api.bitcoincharts.com/v1/weighted_prices.json').iteritems():
+        for currency, info in self.dictForUrl('http://api.bitcoincharts.com/v1/weighted_prices.json').iteritems():
             if currency != "timestamp":
                 self.prices[currency] = info["24h"]


### PR DESCRIPTION
This may fix the NaNBTC (and possibly other related issues) issue that people have on OSX. I'm not able to replicate this but if the reports of this problem vanish after including this, then it could be considered fixed. 

bitcoinaverage, bitpay, and blockchain.info all force https but bitcoincharts allows http.

Pro: newbies on OSX won't have to go through the fixing steps detailed here https://github.com/OpenBazaar/OpenBazaar-Client/issues/1247#issuecomment-213123969

Con: there is less redundancy for people with this issue.
