### PR TITLE
Add missed dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ python-bitcoinlib
 miniupnpc
 txrudp
 python-libbitcoinclient
+service_identity

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,17 @@ miniupnpc==1.9
 bleach==1.4.2
 html5lib==0.9999999
 service_identity
+pystun
+pynacl
+twisted
+txws
+bleach
+protobuf
+bitcointools
+gnupg
+python-obelisk
+txrestapi
+python-bitcoinlib
+miniupnpc
+txrudp
+python-libbitcoinclient


### PR DESCRIPTION
Now `sudo pip install -r requirements.txt` should work on low python usage environments.