### PR TITLE
Fix NaN Issue

### DIFF
--- a/market/btcprice.py
+++ b/market/btcprice.py
@@ -1,5 +1,6 @@
 __author__ = 'ddustin'
 
+import certifi
 import json
 from threading import Thread, Condition
 from urllib2 import Request, urlopen, URLError
@@ -82,7 +83,7 @@ class BtcPrice(Thread):
     @staticmethod
     def dictForUrl(url):
         request = Request(url)
-        result = urlopen(request, timeout=5).read()
+        result = urlopen(request, cafile=certifi.where(), timeout=5).read()
         return json.loads(result)
 
     def loadbitcoinaverage(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ miniupnpc==1.9
 bleach==1.4.2
 html5lib==0.9999999
 service_identity
+certifi


### PR DESCRIPTION
The problem is that certificate chain checking fails for TLS on older versions of OpenSSL bundled with some OS X installs. This enforces an accepted root CA trust store and enables proper validation of TLS certificates for the hosts we're hitting to get BTC ticker prices from.

A new dependency is included so you will need to pip install it.