### PR TITLE
Remove obcentral seed server

### DIFF
--- a/ob.cfg
+++ b/ob.cfg
@@ -28,7 +28,6 @@ testnet_server4 = tcp://libbitcoin4.openbazaar.org:9091,<Z&{.=LJSPySefIKgCu99w.L
 
 [MAINNET_SEEDS]
 mainnet_seed2 = seed2.openbazaar.org:8080,8b17082a57d648894a5181cb6e1b8a6f5b3b7e1c347c0671abfcd7deb6f105fe
-mainnet_seed3 = seed.obcentral.org:8080,f0ff751b27ddaa86a075aa09785c438cd2cebadb8f0f5a7e16f383911322d4ee
 
 [TESTNET_SEEDS]
 testnet_seed1 = seed.openbazaar.org:8080,5b44be5c18ced1bc9400fe5e79c8ab90204f06bebacc04dd9c70a95eaca6e117


### PR DESCRIPTION
It seems that obcentral seed server is dead at this point so better to remove it.