### PR TITLE
Add default network to docker start args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ VOLUME /root/.openbazaar
 VOLUME /ssl
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["python", "openbazaard.py", "start"]
+CMD ["python", "openbazaard.py", "start", "-a 0.0.0.0"]


### PR DESCRIPTION
For me, it defaulted to localhost, which failed to expose the ports externally.