### PR TITLE
Copyright symbol instead of (c)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2017 OpenBazaar Developers
+Copyright © 2015-2017 OpenBazaar Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The use of the symbol is described in United States copyright law, and, internationally, by the Universal Copyright Convention.